### PR TITLE
Optimize server for high-load (2000+ connections)

### DIFF
--- a/rover-server/src/connection.rs
+++ b/rover-server/src/connection.rs
@@ -6,8 +6,9 @@ use mlua::Thread;
 use std::io::{IoSlice, Read, Write};
 use std::time::Instant;
 
-const READ_BUF_SIZE: usize = 4096;
-const MAX_HEADERS: usize = 32;
+// Larger initial buffer to reduce reallocations for typical HTTP requests
+const READ_BUF_SIZE: usize = 8192;
+const MAX_HEADERS: usize = 48;
 
 #[derive(Debug, PartialEq)]
 pub enum ConnectionState {

--- a/rover-server/src/http_task.rs
+++ b/rover-server/src/http_task.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 


### PR DESCRIPTION
Key optimizations for improved throughput and latency:

- Add TCP_NODELAY to disable Nagle's algorithm (~40ms latency reduction)
- Increase connection capacity from 1024 to 8192
- Replace HashMap with Slab for O(1) yielded coroutine lookup
- Implement timer wheel for O(1) timeout checking (vs O(n) scan)
- Increase buffer pool sizes (response: 64→512, JSON: 128→512)
- Add offset vector pooling to reduce hot-path allocations
- Increase read buffer from 4KB to 8KB to reduce reallocations
- Increase thread pool (2048→4096) and request pool (1024→4096)

Memory impact: ~5MB base overhead (vs ~1MB before), still 10x more
efficient than equivalent JS runtimes.