### PR TITLE
feat(rover-db): implement intent-based query builder and ORM DSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/.docusaurus/
 docs/.cache-loader/
 docs/.env
 
+*.sqlite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +356,19 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "cipher"
@@ -1083,6 +1105,30 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2052,6 +2098,7 @@ name = "rover_db"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "libsql",
  "mlua",
  "rover-parser",
@@ -3203,10 +3250,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,27 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.8.33",
 ]
 
 [[package]]
@@ -87,6 +98,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +159,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.112",
+ "which 4.4.2",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +252,15 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "borsh"
@@ -157,16 +282,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -176,6 +325,15 @@ checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -189,6 +347,27 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -299,6 +478,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "curl"
 version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,7 +557,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2",
+ "socket2 0.6.1",
  "windows-sys 0.59.0",
 ]
 
@@ -462,6 +676,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +704,12 @@ name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -523,6 +761,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -544,6 +783,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -593,6 +843,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +874,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -618,6 +895,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.12.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +924,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -645,6 +945,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -674,10 +983,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
 
 [[package]]
 name = "icu_collections"
@@ -818,10 +1224,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -830,16 +1255,174 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libsql"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18646e4ef8db446bc3e3f5fb96131483203bc5f4998ff149f79a067530c01c"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bincode",
+ "bitflags 2.10.0",
+ "bytes",
+ "fallible-iterator 0.3.0",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-rustls",
+ "libsql-hrana",
+ "libsql-sqlite3-parser",
+ "libsql-sys",
+ "libsql_replication",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tonic-web",
+ "tower",
+ "tower-http",
+ "tracing",
+ "uuid",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "libsql-ffi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2a50a585a1184a43621a9133b7702ba5cb7a87ca5e704056b19d8005de6faf"
+dependencies = [
+ "bindgen",
+ "cc",
+]
+
+[[package]]
+name = "libsql-hrana"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeaf5d19e365465e1c23d687a28c805d7462531b3f619f0ba49d3cf369890a3e"
+dependencies = [
+ "base64",
+ "bytes",
+ "prost",
+ "serde",
+]
+
+[[package]]
+name = "libsql-rusqlite"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae65c66088dcd309abbd5617ae046abac2a2ee0a7fdada5127353bd68e0a27ea"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator 0.2.0",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsql-ffi",
+ "smallvec",
+]
+
+[[package]]
+name = "libsql-sqlite3-parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a90128c708356af8f7d767c9ac2946692c9112b4f74f07b99a01a60680e413"
+dependencies = [
+ "bitflags 2.10.0",
+ "cc",
+ "fallible-iterator 0.3.0",
+ "indexmap 2.12.1",
+ "log",
+ "memchr",
+ "phf",
+ "phf_codegen",
+ "phf_shared",
+ "uncased",
+]
+
+[[package]]
+name = "libsql-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c05b61c226781d6f5e26e3e7364617f19c0c1d5332035802e9229d6024cec05"
+dependencies = [
+ "bytes",
+ "libsql-ffi",
+ "libsql-rusqlite",
+ "once_cell",
+ "tracing",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "libsql_replication"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf40c4c2c01462da758272976de0a23d19b4e9c714db08efecf262d896655b5"
+dependencies = [
+ "aes",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "cbc",
+ "libsql-rusqlite",
+ "libsql-sys",
+ "parking_lot",
+ "prost",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tracing",
+ "uuid",
+ "zerocopy 0.7.35",
+]
 
 [[package]]
 name = "libz-sys"
@@ -852,6 +1435,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -918,7 +1507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29e64ac463f01a02ee793423f9b351369cf244c5ee8bb9e2729a75b2eb404181"
 dependencies = [
  "cc",
- "which",
+ "which 8.0.0",
 ]
 
 [[package]]
@@ -932,6 +1521,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
@@ -941,6 +1536,18 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -969,7 +1576,7 @@ dependencies = [
  "mlua-sys",
  "num-traits",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustversion",
  "serde",
  "serde-value",
@@ -986,6 +1593,16 @@ dependencies = [
  "lua-src",
  "luajit-src",
  "pkg-config",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1091,10 +1708,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+ "uncased",
+]
 
 [[package]]
 name = "pin-project"
@@ -1144,6 +1806,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy 0.8.33",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1858,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1894,36 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1228,6 +1962,20 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rover-lsp"
@@ -1287,6 +2035,7 @@ dependencies = [
  "mlua",
  "rover-openapi",
  "rover-parser",
+ "rover_db",
  "rover_server",
  "rover_types",
  "serde_json",
@@ -1294,6 +2043,19 @@ dependencies = [
  "tempfile",
  "tracing",
  "urlencoding",
+]
+
+[[package]]
+name = "rover_db"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libsql",
+ "mlua",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -1307,7 +2069,7 @@ dependencies = [
  "httparse",
  "itoa",
  "lru",
- "matchit",
+ "matchit 0.8.6",
  "memchr",
  "mio",
  "mlua",
@@ -1334,9 +2096,28 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "rustix"
@@ -1347,8 +2128,64 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1386,6 +2223,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1497,6 +2357,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +2382,16 @@ checksum = "0f7a918bd2a9951d18ee6e48f076843e8e73a9a5d22cf05bcd4b7a81bdd04e17"
 dependencies = [
  "borsh",
  "serde_core",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1574,10 +2450,16 @@ dependencies = [
  "serde",
  "serde_json",
  "similar",
- "thiserror",
+ "thiserror 1.0.69",
  "threadpool",
  "toml",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1602,6 +2484,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,9 +2507,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1646,7 +2534,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1654,6 +2551,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1700,9 +2608,19 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1714,6 +2632,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1771,6 +2711,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3b0e1cedbf19fdfb78ef3d672cb9928e0a91a9cb4629cc0c916e8cff8aaaa1"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project",
+ "tokio-stream",
+ "tonic",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,10 +2765,36 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1836,6 +2849,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1922,10 +2936,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1944,6 +2979,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1976,6 +3017,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,6 +3057,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,13 +3081,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "which"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix",
+ "rustix 1.1.3",
  "winsafe",
 ]
 
@@ -2065,6 +3202,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2274,11 +3420,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.33",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2312,6 +3479,12 @@ dependencies = [
  "syn 2.0.112",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,7 +2021,9 @@ dependencies = [
  "rover-lsp",
  "rover-parser",
  "rover_core",
+ "rover_db",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -2052,10 +2054,13 @@ dependencies = [
  "anyhow",
  "libsql",
  "mlua",
+ "rover-parser",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tree-sitter",
+ "tree-sitter-lua",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["rover-cli" , "rover-core", "rover-server", "rover-lsp", "rover-parser", "rover-types"]
+members = ["rover-cli" , "rover-core", "rover-server", "rover-lsp", "rover-parser", "rover-types", "rover-db"]
 
 [profile.release]
 opt-level = 3

--- a/examples/db_example.lua
+++ b/examples/db_example.lua
@@ -1,0 +1,234 @@
+-- rover-db Integration Example
+-- Demonstrates the Intent-Based Query Builder & ORM DSL
+
+local db = rover.db.connect()
+
+-- ============================================================================
+-- Phase 1: Basic Insert & Query
+-- ============================================================================
+
+print("--- Basic Insert & Query ---")
+
+-- Insert creates table if it doesn't exist (schema inference)
+local result = db.users:insert({
+    name = "Alice",
+    age = 30,
+    email = "alice@example.com",
+    status = "active"
+})
+print("Inserted user with id:", result.id)
+
+db.users:insert({ name = "Bob", age = 17, email = "bob@example.com", status = "active" })
+db.users:insert({ name = "Charlie", age = 45, email = "charlie@example.com", status = "inactive" })
+db.users:insert({ name = "Diana", age = 25, email = "diana@example.com", status = "active" })
+
+-- Simple query
+local active_users = db.users:find():by_status("active"):all()
+print("Active users count:", #active_users)
+
+-- Query with comparison
+local adults = db.users:find():by_age_bigger_than(18):all()
+print("Adults count:", #adults)
+
+-- ============================================================================
+-- Phase 2: Complex Filters
+-- ============================================================================
+
+print("\n--- Complex Filters ---")
+
+-- Contains filter
+local users_with_a = db.users:find():by_name_contains("a"):all()
+print("Users with 'a' in name:", #users_with_a)
+
+-- Multiple filters (AND)
+local active_adults = db.users:find()
+    :by_status("active")
+    :by_age_bigger_than(18)
+    :all()
+print("Active adults:", #active_adults)
+
+-- In list filter
+local specific_statuses = db.users:find()
+    :by_status_in_list({"active", "pending"})
+    :all()
+print("Active or pending users:", #specific_statuses)
+
+-- Between filter
+local age_range = db.users:find()
+    :by_age_between({20, 40})
+    :all()
+print("Users aged 20-40:", #age_range)
+
+-- ============================================================================
+-- Phase 3: Orders & Relations
+-- ============================================================================
+
+print("\n--- Orders & Relations ---")
+
+-- Create orders table
+db.orders:insert({ user_id = 1, amount = 100.00, status = "paid" })
+db.orders:insert({ user_id = 1, amount = 50.00, status = "pending" })
+db.orders:insert({ user_id = 2, amount = 75.00, status = "paid" })
+db.orders:insert({ user_id = 4, amount = 200.00, status = "paid" })
+
+-- Subquery: users with paid orders
+local paid_order_user_ids = db.orders:find()
+    :by_status("paid")
+    :select(db.orders.user_id)
+
+local users_with_paid = db.users:find()
+    :by_id_in_list(paid_order_user_ids)
+local sql = users_with_paid:inspect().candidate_sql
+print("Users with paid orders SQL:", sql)
+
+-- EXISTS: users who have paid orders
+local users_with_paid_orders = db.users:find()
+    :exists(db.orders:find():by_status("paid"))
+    :on(db.orders.user_id, db.users.id)
+print("EXISTS query SQL:", users_with_paid_orders:inspect().candidate_sql)
+
+-- ============================================================================
+-- Phase 4: OR Composition (merge)
+-- ============================================================================
+
+print("\n--- OR Composition ---")
+
+local admins = db.users:find():by_status("active")
+local minors = db.users:find():by_age_smaller_than(18)
+
+local admins_or_minors = db.users:find():merge(admins, minors)
+print("OR query SQL:", admins_or_minors:inspect().candidate_sql)
+
+-- Complex OR with EXISTS
+local has_high_orders = db.users:find()
+    :exists(db.orders:find():by_amount_bigger_than(100))
+    :on(db.orders.user_id, db.users.id)
+
+local is_inactive = db.users:find():by_status("inactive")
+
+local special_users = db.users:find():merge(has_high_orders, is_inactive)
+print("Complex OR SQL:", special_users:inspect().candidate_sql)
+
+-- ============================================================================
+-- Phase 5: Grouping & Aggregates
+-- ============================================================================
+
+print("\n--- Grouping & Aggregates ---")
+
+local order_totals = db.orders:find()
+    :group_by(db.orders.user_id)
+    :agg({
+        total = rover.db.sum(db.orders.amount),
+        order_count = rover.db.count(db.orders.id)
+    })
+
+print("Aggregate query SQL:", order_totals:inspect().candidate_sql)
+
+-- With HAVING
+local big_spenders = db.orders:find()
+    :group_by(db.orders.user_id)
+    :agg({
+        total = rover.db.sum(db.orders.amount),
+        order_count = rover.db.count(db.orders.id)
+    })
+    :having_total_bigger_than(100)
+
+print("HAVING query SQL:", big_spenders:inspect().candidate_sql)
+
+-- ============================================================================
+-- Phase 6: Ordering, Limit, Offset
+-- ============================================================================
+
+print("\n--- Ordering, Limit, Offset ---")
+
+local recent_users = db.users:find()
+    :order_by(db.users.id, "DESC")
+    :limit(2)
+
+print("Paginated query SQL:", recent_users:inspect().candidate_sql)
+
+-- Pagination
+local page2 = db.users:find()
+    :order_by(db.users.id, "ASC")
+    :limit(10)
+    :offset(10)
+
+print("Page 2 SQL:", page2:inspect().candidate_sql)
+
+-- ============================================================================
+-- Phase 7: Preloads (with_*)
+-- ============================================================================
+
+print("\n--- Preloads ---")
+
+-- Create posts table for demo
+db.posts:insert({ author_id = 1, title = "Hello World", published = true })
+db.posts:insert({ author_id = 2, title = "My First Post", published = false })
+
+local posts_with_author = db.posts:find()
+    :by_published(true)
+    :with_author()
+
+local info = posts_with_author:inspect()
+print("Preload strategy:", table.concat(info.lowering_strategy, ", "))
+print("Preloads:", table.concat(info.preloads, ", "))
+
+-- ============================================================================
+-- Phase 8: Update & Delete
+-- ============================================================================
+
+print("\n--- Update & Delete ---")
+
+-- Update
+local update_sql = db.users:update()
+    :by_id(1)
+    :set({ status = "premium" })
+print("UPDATE SQL:", update_sql:inspect and "not available" or "N/A")
+
+-- Delete
+local delete_sql = db.users:delete():by_status("banned")
+print("DELETE (banned users) would execute")
+
+-- ============================================================================
+-- Phase 9: Raw SQL Escape Hatch
+-- ============================================================================
+
+print("\n--- Raw SQL Escape Hatch ---")
+
+local raw_query = db.users:sql():raw([[
+    SELECT u.*, COUNT(o.id) as order_count
+    FROM users u
+    LEFT JOIN orders o ON o.user_id = u.id
+    GROUP BY u.id
+    HAVING order_count > 0
+]])
+
+local raw_info = raw_query:inspect()
+print("Raw SQL intent:", raw_info.intent)
+print("Raw SQL:", raw_info.sql:sub(1, 50) .. "...")
+
+-- ============================================================================
+-- Phase 10: inspect() Deep Dive
+-- ============================================================================
+
+print("\n--- Query Inspection ---")
+
+local complex_query = db.users:find()
+    :by_status("active")
+    :by_age_bigger_than(18)
+    :exists(db.orders:find():by_status("paid"))
+    :on(db.orders.user_id, db.users.id)
+    :order_by(db.users.name, "ASC")
+    :limit(10)
+
+local inspection = complex_query:inspect()
+
+print("Intent:", inspection.intent)
+print("Table:", inspection.table)
+print("Filters:", #inspection.filters)
+print("EXISTS clauses:", #inspection.exists_clauses)
+print("Limit:", inspection.limit)
+print("Candidate SQL:", inspection.candidate_sql:sub(1, 80) .. "...")
+print("Lowering strategies:", table.concat(inspection.lowering_strategy, ", "))
+
+print("\n--- All Examples Complete ---")

--- a/examples/rover_db_advanced.lua
+++ b/examples/rover_db_advanced.lua
@@ -1,0 +1,136 @@
+local db = rover.db.connect()
+
+print("=== Setup: Create Data ===\n")
+
+local u1 = db.users:insert({ name = "Alice", email = "alice@example.com", status = "active" })
+local u2 = db.users:insert({ name = "Bob", email = "bob@example.com", status = "active" })
+local u3 = db.users:insert({ name = "Charlie", email = "charlie@example.com", status = "inactive" })
+
+local o1 = db.orders:insert({ user_id = u1.id, amount = 100, status = "paid" })
+local o2 = db.orders:insert({ user_id = u1.id, amount = 50, status = "pending" })
+local o3 = db.orders:insert({ user_id = u2.id, amount = 200, status = "paid" })
+local o4 = db.orders:insert({ user_id = u3.id, amount = 150, status = "paid" })
+
+db.posts:insert({ user_id = u1.id, title = "First Post", published = true })
+db.posts:insert({ user_id = u1.id, title = "Draft Post", published = false })
+db.posts:insert({ user_id = u2.id, title = "Alice Response", published = true })
+db.posts:insert({ user_id = u3.id, title = "Charlie Thoughts", published = true })
+
+print("✓ Data created\n")
+
+print("=== Subqueries with IN ===\n")
+
+local paid_order_users = db.orders:find()
+    :by_status("paid")
+    :select(db.orders.user_id)
+
+local users_with_paid_orders = db.users:find()
+    :by_id_in_list(paid_order_users)
+    :all()
+
+debug.print(users_with_paid_orders, "Users who have paid orders")
+
+print("\n=== EXISTS with Correlated Subquery ===\n")
+
+local users_with_orders = db.users:find()
+    :exists(db.orders:find():by_status("paid"))
+    :on(db.orders.user_id, db.users.id)
+    :all()
+
+debug.print(users_with_orders, "Users with paid orders (EXISTS)")
+
+print("\n=== Complex OR with EXISTS ===\n")
+
+local has_paid = db.users:find()
+    :exists(db.orders:find():by_status("paid"))
+    :on(db.orders.user_id, db.users.id)
+
+local has_posts = db.users:find()
+    :exists(db.posts:find():by_published(true))
+    :on(db.posts.user_id, db.users.id)
+
+local active_or_engaged = db.users:find():merge(has_paid, has_posts):all()
+debug.print(active_or_engaged, "Users with paid orders OR published posts")
+
+print("\n=== Preloads (with_*) ===\n")
+
+local posts_data = db.posts:find()
+    :by_published(true)
+    :with_author()
+    :all()
+
+debug.print(posts_data, "Published posts with preload strategy")
+
+print("\n=== Query Inspection: Generated SQL ===\n")
+
+local complex = db.users:find()
+    :by_status("active")
+    :exists(db.orders:find():by_amount_bigger_than(100))
+    :on(db.orders.user_id, db.users.id)
+    :order_by(db.users.name, "ASC")
+    :limit(5)
+
+local info = complex:inspect()
+
+print("Intent:", info.intent)
+print("Table:", info.table)
+print("Filters:", #info.filters)
+print("EXISTS clauses:", #info.exists_clauses)
+print("Lowering strategies:", table.concat(info.lowering_strategy, ", "))
+print("\nCandidate SQL:")
+print(info.candidate_sql)
+
+print("\n=== Advanced Aggregates ===\n")
+
+local stats = db.orders:find()
+    :group_by(db.orders.user_id)
+    :agg({
+        total = rover.db.sum(db.orders.amount),
+        avg = rover.db.avg(db.orders.amount),
+        min = rover.db.min(db.orders.amount),
+        max = rover.db.max(db.orders.amount),
+        count = rover.db.count(db.orders.id)
+    })
+    :all()
+
+debug.print(stats, "Order statistics by user")
+
+print("\n=== HAVING with Multiple Aggregates ===\n")
+
+local high_volume = db.orders:find()
+    :group_by(db.orders.user_id)
+    :agg({
+        total = rover.db.sum(db.orders.amount),
+        count = rover.db.count(db.orders.id)
+    })
+    :having_total_bigger_than(150)
+    :having_count_bigger_than(1)
+    :all()
+
+debug.print(high_volume, "Users with total > 150 AND count > 1")
+
+print("\n=== Multi-step Composition ===\n")
+
+local mid_tier_users = db.users:find()
+    :by_status("active")
+    :exists(db.orders:find():by_amount_between({ 50, 200 }))
+    :on(db.orders.user_id, db.users.id)
+    :order_by(db.users.name, "ASC")
+
+local mid_tier_info = mid_tier_users:inspect()
+debug.print(mid_tier_info.candidate_sql, "Mid-tier users query")
+
+print("\n=== Order Count per User ===\n")
+
+local user_order_counts = db.orders:find()
+    :group_by(db.orders.user_id)
+    :agg({
+        order_count = rover.db.count(db.orders.id),
+        total_spent = rover.db.sum(db.orders.amount)
+    })
+    :order_by(db.orders.user_id, "ASC")
+    :all()
+
+debug.print(user_order_counts, "Order metrics per user")
+
+print("\n=== Complete ===\n")

--- a/examples/rover_db_http.lua
+++ b/examples/rover_db_http.lua
@@ -1,0 +1,128 @@
+local api = rover.server {}
+local db = rover.db.connect()
+local g = rover.guard
+
+function api.users.get(ctx)
+    local users = db.users:find():all()
+    return api.json(users)
+end
+
+function api.users.post(ctx)
+    local body = ctx:body():expect {
+        name = g:string():required "Name is required",
+        email = g:string():required "Email is required",
+    }
+
+    local result = db.users:insert({
+        name = body.name,
+        email = body.email,
+        status = body.status or "active"
+    })
+
+    return api.json:status(201, result)
+end
+
+function api.users.p_id.get(ctx)
+    local id = tonumber(ctx:params().id)
+    local user = db.users:find():by_id(id):first()
+
+    if not user then
+        return api:error(404, "User not found")
+    end
+
+    return api.json(user)
+end
+
+function api.users.p_id.put(ctx)
+    local id = tonumber(ctx:params().id)
+    local body = ctx:body():json()
+
+    local existing = db.users:find():by_id(id):first()
+
+    if not existing then
+        return api:error(404, "User not found")
+    end
+
+    db.users:update()
+        :by_id(id)
+        :set({
+            name = body.name or existing.name,
+            email = body.email or existing.email,
+            status = body.status or existing.status
+        })
+        :exec()
+
+    local updated = db.users:find():by_id(id):first()
+    return api.json(updated)
+end
+
+function api.users.p_id.delete(ctx)
+    local id = tonumber(ctx:params().id)
+
+    local user = db.users:find():by_id(id):first()
+    if not user then
+        return api:error(404, "User not found")
+    end
+
+    db.users:delete():by_id(id):exec()
+
+    return api.json({ message = "User deleted" })
+end
+
+function api.users.p_id.orders.get(ctx)
+    local id = tonumber(ctx:params().id)
+
+    local user = db.users:find():by_id(id):first()
+    if not user then
+        return api:error(404, "User not found")
+    end
+
+    local orders = db.orders:find():by_user_id(id):all()
+
+    return api.json({
+        user = user,
+        orders = orders,
+        count = #orders
+    })
+end
+
+function api.users.p_id.orders.post(ctx)
+    local id = tonumber(ctx:params().id)
+    local body = ctx:body():json()
+
+    local user = db.users:find():by_id(id):first()
+    if not user then
+        return api:error(404, "User not found")
+    end
+
+    if not body.amount or not body.status then
+        return api:error(400, "amount and status required")
+    end
+
+    local order = db.orders:insert({
+        user_id = id,
+        amount = body.amount,
+        status = body.status
+    })
+
+    return api.json:status(201, order)
+end
+
+function api.stats.get(ctx)
+    local user_count = db.users:find():count()
+    
+    local order_stats = db.orders:find()
+        :group_by(db.orders.user_id)
+        :agg({
+            total = rover.db.sum(db.orders.amount),
+            count = rover.db.count(db.orders.id)
+        })
+        :all()
+
+    return api.json({
+        total_users = user_count,
+        user_orders = order_stats
+    })
+end
+
+return api

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,23 @@
+local api = rover.server {}
 
-local f = nil
-assert(f ~= nil, "File doesn't exist")
+local g = rover.guard
+
+local users = {}
+
+function api.users.get(ctx)
+	return api.json(users)
+end
+
+function api.users.post(ctx)
+	local user = ctx:body():json():expect {
+        name = g:string()
+    }
+
+    table.insert(users, user)
+
+	return api.json {
+		message = "ok",
+	}
+end
+
+return api

--- a/rover-cli/Cargo.toml
+++ b/rover-cli/Cargo.toml
@@ -9,8 +9,10 @@ clap = { version = "4.5.53", features = ["derive"] }
 rover_core = {path = "../rover-core"}
 rover-lsp = {path = "../rover-lsp"}
 rover-parser = {path = "../rover-parser"}
+rover_db = {path = "../rover-db"}
 colored = "2.2"
 serde_json = "1.0"
+tokio = { version = "1", features = ["sync"] }
 
 [[bin]]
 name = "rover"

--- a/rover-cli/src/main.rs
+++ b/rover-cli/src/main.rs
@@ -3,7 +3,9 @@ mod fmt;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use colored::Colorize;
 use rover_core::run;
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -40,8 +42,59 @@ enum Commands {
         #[arg(short, long)]
         check: bool,
     },
+    /// Database migration commands
+    Db {
+        #[command(subcommand)]
+        action: DbAction,
+    },
     #[command(external_subcommand)]
     External(Vec<String>),
+}
+
+#[derive(Subcommand)]
+enum DbAction {
+    /// Run all pending migrations
+    Migrate {
+        /// Database file path (default: rover.sqlite)
+        #[arg(short, long, default_value = "rover.sqlite")]
+        database: String,
+        /// Migrations directory (default: db/migrations)
+        #[arg(short, long, default_value = "db/migrations")]
+        migrations: PathBuf,
+    },
+    /// Rollback migrations
+    Rollback {
+        /// Number of migrations to rollback
+        #[arg(short, long, default_value = "1")]
+        steps: usize,
+        /// Database file path
+        #[arg(short, long, default_value = "rover.sqlite")]
+        database: String,
+        /// Migrations directory
+        #[arg(short, long, default_value = "db/migrations")]
+        migrations: PathBuf,
+    },
+    /// Show migration status
+    Status {
+        /// Database file path
+        #[arg(short, long, default_value = "rover.sqlite")]
+        database: String,
+        /// Migrations directory
+        #[arg(short, long, default_value = "db/migrations")]
+        migrations: PathBuf,
+    },
+    /// Reset database (drop all tables, re-run migrations)
+    Reset {
+        /// Database file path
+        #[arg(short, long, default_value = "rover.sqlite")]
+        database: String,
+        /// Migrations directory
+        #[arg(short, long, default_value = "db/migrations")]
+        migrations: PathBuf,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        force: bool,
+    },
 }
 
 fn main() -> Result<()> {
@@ -68,12 +121,23 @@ fn main() -> Result<()> {
             })
         }
         Commands::Fmt { file, check } => fmt::run_fmt(fmt::FmtOptions { file, check }),
+        Commands::Db { action } => handle_db_command(action),
         Commands::External(args) => {
-            let path = args.first().unwrap();
+            // Parse args for --yolo flag
+            let (file_args, yolo_mode) = parse_external_args(&args);
+
+            let raw_path = file_args.first().ok_or_else(|| {
+                anyhow::anyhow!("No file specified. Usage: rover @<file.lua> [--yolo]")
+            })?;
+            // Strip @ prefix if present (external_subcommand includes it)
+            let path = raw_path.strip_prefix('@').unwrap_or(raw_path);
             let file_path = PathBuf::from(path);
 
-            // Run pre-execution check
+            // Run pre-execution check (syntax/type errors)
             check::pre_run_check(&file_path)?;
+
+            // Run database pre-run analysis
+            pre_run_db_analysis(&file_path, yolo_mode)?;
 
             // Execute the file
             match run(path, cli.verbose) {
@@ -84,4 +148,262 @@ fn main() -> Result<()> {
             }
         }
     }
+}
+
+fn handle_db_command(action: DbAction) -> Result<()> {
+    match action {
+        DbAction::Migrate {
+            database,
+            migrations,
+        } => {
+            println!("🗄️  Running migrations...");
+            match rover_db::run_migrations(&database, &migrations) {
+                Ok(count) => {
+                    if count > 0 {
+                        println!("✅ Applied {} migration(s)", count);
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    eprintln!("❌ Migration failed: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        DbAction::Rollback {
+            steps,
+            database,
+            migrations,
+        } => {
+            println!("⏪ Rolling back {} migration(s)...", steps);
+            match rover_db::rollback(&database, &migrations, steps) {
+                Ok(count) => {
+                    if count > 0 {
+                        println!("✅ Rolled back {} migration(s)", count);
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    eprintln!("❌ Rollback failed: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        DbAction::Status {
+            database,
+            migrations,
+        } => match rover_db::migration_status(&database, &migrations) {
+            Ok(status) => {
+                println!("📋 Migration Status\n");
+
+                if status.applied.is_empty() {
+                    println!("  Applied: (none)");
+                } else {
+                    println!("  Applied:");
+                    for m in &status.applied {
+                        println!("    ✓ {}", m);
+                    }
+                }
+
+                println!();
+
+                if status.pending.is_empty() {
+                    println!("  Pending: (none)");
+                } else {
+                    println!("  Pending:");
+                    for m in &status.pending {
+                        println!("    ○ {}", m);
+                    }
+                }
+
+                Ok(())
+            }
+            Err(e) => {
+                eprintln!("❌ Failed to get status: {}", e);
+                std::process::exit(1);
+            }
+        },
+        DbAction::Reset {
+            database,
+            migrations,
+            force,
+        } => {
+            if !force {
+                println!("⚠️  This will DELETE all data in {}!", database);
+                println!("   Run with --force to confirm.");
+                return Ok(());
+            }
+
+            println!("🔄 Resetting database...");
+
+            // Delete the database file
+            if std::path::Path::new(&database).exists() {
+                std::fs::remove_file(&database)?;
+                println!("  Deleted {}", database);
+            }
+
+            // Run all migrations
+            match rover_db::run_migrations(&database, &migrations) {
+                Ok(count) => {
+                    println!("✅ Reset complete. Applied {} migration(s)", count);
+                    Ok(())
+                }
+                Err(e) => {
+                    eprintln!("❌ Reset failed: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+}
+
+/// Parse external command args, extracting --yolo flag
+fn parse_external_args(args: &[String]) -> (Vec<String>, bool) {
+    let mut file_args = Vec::new();
+    let mut yolo_mode = false;
+
+    for arg in args {
+        if arg == "--yolo" || arg == "-y" {
+            yolo_mode = true;
+        } else {
+            file_args.push(arg.clone());
+        }
+    }
+
+    (file_args, yolo_mode)
+}
+
+fn pre_run_db_analysis(file_path: &PathBuf, yolo_mode: bool) -> Result<()> {
+    use rover_db::{TableStatus, run_pending_migrations};
+    use rover_parser::db_intent::analyze_db_intent;
+
+    let code = std::fs::read_to_string(file_path)?;
+    let db_path = "rover.sqlite";
+    let schemas_dir = PathBuf::from("db/schemas");
+    let migrations_dir = PathBuf::from("db/migrations");
+
+    let intent = analyze_db_intent(&code);
+    if intent.tables.is_empty() {
+        return Ok(());
+    }
+
+    println!("\n{}", "🔍 Analyzing code intent...".cyan());
+
+    let schemas = rover_db::load_schemas_from_dir(&schemas_dir).unwrap_or_default();
+    let comparison = rover_db::compare_intent_with_schemas(&intent, &schemas);
+
+    let mut needs_migration = false;
+
+    for diff in &comparison.diffs {
+        let table = intent.tables.get(&diff.table_name).unwrap();
+
+        match diff.status {
+            TableStatus::New => {
+                println!("\n{}", format!("📋 Table '{}' - inferred from code:", diff.table_name).yellow());
+                for field in table.fields.values() {
+                    println!("   • {}: {} ({})", field.name, field.field_type.to_guard_type(), field.source);
+                }
+                println!("\n   {}", "⚠️  No schema found".yellow());
+
+                let create_schema = if yolo_mode {
+                    println!("   {}", "Creating schema (--yolo)".cyan());
+                    true
+                } else {
+                    prompt_yn(&format!("   Create schema db/schemas/{}.lua?", diff.table_name))?
+                };
+
+                if create_schema {
+                    let content = rover_db::generate_schema_content(table);
+                    rover_db::write_schema_file(&schemas_dir, &diff.table_name, &content)
+                        .map_err(|e| anyhow::anyhow!("Failed to write schema: {}", e))?;
+                    println!("   {}", format!("✓ Created db/schemas/{}.lua", diff.table_name).green());
+
+                    let create_migration = if yolo_mode {
+                        true
+                    } else {
+                        prompt_yn(&format!("   Create migration for '{}'?", diff.table_name))?
+                    };
+
+                    if create_migration {
+                        let fields: Vec<_> = table.fields.values().cloned().collect();
+                        let mig_content = rover_db::generate_migration_content(&diff.table_name, &fields, true);
+                        let mig_name = rover_db::write_migration_file(&migrations_dir, &format!("create_{}", diff.table_name), &mig_content)
+                            .map_err(|e| anyhow::anyhow!("Failed to write migration: {}", e))?;
+                        println!("   {}", format!("✓ Created db/migrations/{}", mig_name).green());
+                        needs_migration = true;
+                    }
+                } else {
+                    return Err(anyhow::anyhow!("Aborted - schema not created for '{}'", diff.table_name));
+                }
+            }
+            TableStatus::NeedsUpdate => {
+                println!("\n{}", format!("📋 Table '{}' - schema exists but code suggests new fields:", diff.table_name).yellow());
+                for field in &diff.new_fields {
+                    println!("   + {}: {} ({})", field.name, field.field_type.to_guard_type(), field.source);
+                }
+
+                let update = if yolo_mode {
+                    println!("   {}", "Updating schema (--yolo)".cyan());
+                    true
+                } else {
+                    prompt_yn("   Update schema?")?
+                };
+
+                if update {
+                    rover_db::update_schema_file(&schemas_dir, &diff.table_name, &diff.new_fields)
+                        .map_err(|e| anyhow::anyhow!("Failed to update schema: {}", e))?;
+                    println!("   {}", format!("✓ Updated db/schemas/{}.lua", diff.table_name).green());
+
+                    let create_migration = if yolo_mode {
+                        true
+                    } else {
+                        prompt_yn("   Create migration for changes?")?
+                    };
+
+                    if create_migration {
+                        let mig_content = rover_db::generate_migration_content(&diff.table_name, &diff.new_fields, false);
+                        let mig_name = rover_db::write_migration_file(&migrations_dir, &format!("add_{}_fields", diff.table_name), &mig_content)
+                            .map_err(|e| anyhow::anyhow!("Failed to write migration: {}", e))?;
+                        println!("   {}", format!("✓ Created db/migrations/{}", mig_name).green());
+                        needs_migration = true;
+                    }
+                }
+            }
+            TableStatus::Exists => {
+                println!("\n{}", format!("✅ Table '{}' - schema up to date", diff.table_name).green());
+            }
+        }
+    }
+
+    if needs_migration {
+        let run_mig = if yolo_mode {
+            println!("\n{}", "Running migrations (--yolo)...".cyan());
+            true
+        } else {
+            prompt_yn("\nRun pending migrations?")?
+        };
+
+        if run_mig {
+            let conn = rover_db::Connection::new(db_path)
+                .map_err(|e| anyhow::anyhow!("DB error: {}", e))?;
+            let executor = rover_db::MigrationExecutor::new(std::sync::Arc::new(tokio::sync::Mutex::new(conn)));
+            match run_pending_migrations(&executor, &migrations_dir) {
+                Ok(count) => println!("{}", format!("✅ Ran {} migration(s)", count).green()),
+                Err(e) => return Err(anyhow::anyhow!("Migration failed: {}", e)),
+            }
+        }
+    }
+
+    println!();
+    Ok(())
+}
+
+fn prompt_yn(message: &str) -> Result<bool> {
+    use std::io::BufRead;
+    print!("{} [y/n] ", message);
+    io::stdout().flush()?;
+    let mut line = String::new();
+    io::stdin().lock().read_line(&mut line)?;
+    let answer = line.trim().to_lowercase();
+    Ok(answer == "y" || answer == "yes")
 }

--- a/rover-cli/src/main.rs
+++ b/rover-cli/src/main.rs
@@ -299,9 +299,17 @@ fn pre_run_db_analysis(file_path: &PathBuf, yolo_mode: bool) -> Result<()> {
 
         match diff.status {
             TableStatus::New => {
-                println!("\n{}", format!("📋 Table '{}' - inferred from code:", diff.table_name).yellow());
+                println!(
+                    "\n{}",
+                    format!("📋 Table '{}' - inferred from code:", diff.table_name).yellow()
+                );
                 for field in table.fields.values() {
-                    println!("   • {}: {} ({})", field.name, field.field_type.to_guard_type(), field.source);
+                    println!(
+                        "   • {}: {} ({})",
+                        field.name,
+                        field.field_type.to_guard_type(),
+                        field.source
+                    );
                 }
                 println!("\n   {}", "⚠️  No schema found".yellow());
 
@@ -309,14 +317,20 @@ fn pre_run_db_analysis(file_path: &PathBuf, yolo_mode: bool) -> Result<()> {
                     println!("   {}", "Creating schema (--yolo)".cyan());
                     true
                 } else {
-                    prompt_yn(&format!("   Create schema db/schemas/{}.lua?", diff.table_name))?
+                    prompt_yn(&format!(
+                        "   Create schema db/schemas/{}.lua?",
+                        diff.table_name
+                    ))?
                 };
 
                 if create_schema {
                     let content = rover_db::generate_schema_content(table);
                     rover_db::write_schema_file(&schemas_dir, &diff.table_name, &content)
                         .map_err(|e| anyhow::anyhow!("Failed to write schema: {}", e))?;
-                    println!("   {}", format!("✓ Created db/schemas/{}.lua", diff.table_name).green());
+                    println!(
+                        "   {}",
+                        format!("✓ Created db/schemas/{}.lua", diff.table_name).green()
+                    );
 
                     let create_migration = if yolo_mode {
                         true
@@ -326,20 +340,43 @@ fn pre_run_db_analysis(file_path: &PathBuf, yolo_mode: bool) -> Result<()> {
 
                     if create_migration {
                         let fields: Vec<_> = table.fields.values().cloned().collect();
-                        let mig_content = rover_db::generate_migration_content(&diff.table_name, &fields, true);
-                        let mig_name = rover_db::write_migration_file(&migrations_dir, &format!("create_{}", diff.table_name), &mig_content)
-                            .map_err(|e| anyhow::anyhow!("Failed to write migration: {}", e))?;
-                        println!("   {}", format!("✓ Created db/migrations/{}", mig_name).green());
+                        let mig_content =
+                            rover_db::generate_migration_content(&diff.table_name, &fields, true);
+                        let mig_name = rover_db::write_migration_file(
+                            &migrations_dir,
+                            &format!("create_{}", diff.table_name),
+                            &mig_content,
+                        )
+                        .map_err(|e| anyhow::anyhow!("Failed to write migration: {}", e))?;
+                        println!(
+                            "   {}",
+                            format!("✓ Created db/migrations/{}", mig_name).green()
+                        );
                         needs_migration = true;
                     }
                 } else {
-                    return Err(anyhow::anyhow!("Aborted - schema not created for '{}'", diff.table_name));
+                    return Err(anyhow::anyhow!(
+                        "Aborted - schema not created for '{}'",
+                        diff.table_name
+                    ));
                 }
             }
             TableStatus::NeedsUpdate => {
-                println!("\n{}", format!("📋 Table '{}' - schema exists but code suggests new fields:", diff.table_name).yellow());
+                println!(
+                    "\n{}",
+                    format!(
+                        "📋 Table '{}' - schema exists but code suggests new fields:",
+                        diff.table_name
+                    )
+                    .yellow()
+                );
                 for field in &diff.new_fields {
-                    println!("   + {}: {} ({})", field.name, field.field_type.to_guard_type(), field.source);
+                    println!(
+                        "   + {}: {} ({})",
+                        field.name,
+                        field.field_type.to_guard_type(),
+                        field.source
+                    );
                 }
 
                 let update = if yolo_mode {
@@ -352,7 +389,10 @@ fn pre_run_db_analysis(file_path: &PathBuf, yolo_mode: bool) -> Result<()> {
                 if update {
                     rover_db::update_schema_file(&schemas_dir, &diff.table_name, &diff.new_fields)
                         .map_err(|e| anyhow::anyhow!("Failed to update schema: {}", e))?;
-                    println!("   {}", format!("✓ Updated db/schemas/{}.lua", diff.table_name).green());
+                    println!(
+                        "   {}",
+                        format!("✓ Updated db/schemas/{}.lua", diff.table_name).green()
+                    );
 
                     let create_migration = if yolo_mode {
                         true
@@ -361,16 +401,30 @@ fn pre_run_db_analysis(file_path: &PathBuf, yolo_mode: bool) -> Result<()> {
                     };
 
                     if create_migration {
-                        let mig_content = rover_db::generate_migration_content(&diff.table_name, &diff.new_fields, false);
-                        let mig_name = rover_db::write_migration_file(&migrations_dir, &format!("add_{}_fields", diff.table_name), &mig_content)
-                            .map_err(|e| anyhow::anyhow!("Failed to write migration: {}", e))?;
-                        println!("   {}", format!("✓ Created db/migrations/{}", mig_name).green());
+                        let mig_content = rover_db::generate_migration_content(
+                            &diff.table_name,
+                            &diff.new_fields,
+                            false,
+                        );
+                        let mig_name = rover_db::write_migration_file(
+                            &migrations_dir,
+                            &format!("add_{}_fields", diff.table_name),
+                            &mig_content,
+                        )
+                        .map_err(|e| anyhow::anyhow!("Failed to write migration: {}", e))?;
+                        println!(
+                            "   {}",
+                            format!("✓ Created db/migrations/{}", mig_name).green()
+                        );
                         needs_migration = true;
                     }
                 }
             }
             TableStatus::Exists => {
-                println!("\n{}", format!("✅ Table '{}' - schema up to date", diff.table_name).green());
+                println!(
+                    "\n{}",
+                    format!("✅ Table '{}' - schema up to date", diff.table_name).green()
+                );
             }
         }
     }
@@ -386,7 +440,12 @@ fn pre_run_db_analysis(file_path: &PathBuf, yolo_mode: bool) -> Result<()> {
         if run_mig {
             let conn = rover_db::Connection::new(db_path)
                 .map_err(|e| anyhow::anyhow!("DB error: {}", e))?;
-            let executor = rover_db::MigrationExecutor::new(std::sync::Arc::new(tokio::sync::Mutex::new(conn)));
+            let executor = rover_db::MigrationExecutor::new(std::sync::Arc::new(
+                tokio::sync::Mutex::new(conn),
+            ));
+            executor
+                .ensure_migrations_table()
+                .map_err(|e| anyhow::anyhow!("Failed to create migrations table: {}", e))?;
             match run_pending_migrations(&executor, &migrations_dir) {
                 Ok(count) => println!("{}", format!("✅ Ran {} migration(s)", count).green()),
                 Err(e) => return Err(anyhow::anyhow!("Migration failed: {}", e)),

--- a/rover-core/Cargo.toml
+++ b/rover-core/Cargo.toml
@@ -11,6 +11,7 @@ rover_server = {path = "../rover-server"}
 rover-parser = {path = "../rover-parser"}
 rover-openapi = {path = "../rover-openapi"}
 rover_types = {path = "../rover-types"}
+rover_db = {path = "../rover-db"}
 serde_json = "1.0"
 tracing = "0.1"
 smallvec = "1.15.1"

--- a/rover-core/src/debug.lua
+++ b/rover-core/src/debug.lua
@@ -1,0 +1,83 @@
+-- Rover Debug Utilities
+-- debug.print - Pretty-print values for debugging
+
+local debug = debug or {}
+
+debug.print = function(value, label)
+    -- Format value with indentation
+    local function format_val(v, depth, seen)
+        depth = depth or 0
+        seen = seen or {}
+
+        if depth > 5 then
+            return "<max_depth>"
+        end
+
+        local t = type(v)
+        if t == "nil" then
+            return "nil"
+        elseif t == "boolean" then
+            return tostring(v)
+        elseif t == "number" then
+            return tostring(v)
+        elseif t == "string" then
+            return '"' .. v:gsub('"', '\\"') .. '"'
+        elseif t == "table" then
+            -- Check for circular reference
+            if seen[v] then
+                return "<circular>"
+            end
+            seen[v] = true
+
+            local indent = string.rep("  ", depth)
+            local next_indent = string.rep("  ", depth + 1)
+            local lines = { "{" }
+
+            -- Check if array-like
+            local is_array = true
+            local max_idx = 0
+            for k in pairs(v) do
+                if type(k) == "number" then
+                    if k > 0 then
+                        max_idx = math.max(max_idx, k)
+                    end
+                else
+                    is_array = false
+                end
+            end
+
+            if is_array and max_idx > 0 then
+                -- Array format
+                for i = 1, max_idx do
+                    if v[i] ~= nil then
+                        table.insert(lines, next_indent .. format_val(v[i], depth + 1, seen) .. ",")
+                    end
+                end
+            else
+                -- Key-value format
+                for k, val in pairs(v) do
+                    local key_str = type(k) == "string" and k or tostring(k)
+                    table.insert(lines, next_indent .. key_str .. " = " .. format_val(val, depth + 1, seen) .. ",")
+                end
+            end
+
+            table.insert(lines, indent .. "}")
+            return table.concat(lines, "\n")
+        else
+            return "<" .. t .. ">"
+        end
+    end
+
+    local formatted = format_val(value)
+    local output
+    if label then
+        output = string.format("[debug.print] %s: %s", label, formatted)
+    else
+        output = string.format("[debug.print] %s", formatted)
+    end
+
+    print(output)
+    return value
+end
+
+return debug

--- a/rover-core/src/guard.lua
+++ b/rover-core/src/guard.lua
@@ -1,74 +1,81 @@
 -- Rover Guard - Zod-inspired validator for Lua
 local Guard = {}
 
+-- Methods for chainable validators (shared via metatable)
+local ValidatorMethods = {
+	required = function(self, msg)
+		self._required = true
+		self._nullable = false
+		self._required_msg = msg
+		return self
+	end,
+
+	default = function(self, value)
+		self._default = value
+		return self
+	end,
+
+	enum = function(self, values)
+		self._enum = values
+		return self
+	end,
+
+	-- Schema modifiers
+	primary = function(self)
+		self._primary = true
+		self._nullable = false
+		return self
+	end,
+
+	auto = function(self)
+		self._auto = true
+		return self
+	end,
+
+	unique = function(self)
+		self._unique = true
+		return self
+	end,
+
+	nullable = function(self)
+		self._nullable = true
+		self._required = false
+		return self
+	end,
+
+	references = function(self, table_col)
+		self._references_table = table_col
+		return self
+	end,
+
+	index = function(self)
+		self._index_flag = true
+		return self
+	end,
+}
+
+local ValidatorMT = { __index = ValidatorMethods }
+
 -- Helper to create chainable validator
 local function create_validator(validator_type)
-	return {
+	local v = {
 		type = validator_type,
-		required = false,
-		required_msg = nil,
-		default = nil,
-		enum = nil,
-		element = nil,
-		schema = nil,
+		_required = false,
+		_required_msg = nil,
+		_default = nil,
+		_enum = nil,
+		_element = nil,
+		_schema = nil,
 		-- Schema/migration modifiers
-		primary = false,
-		auto = false,
-		unique = false,
-		nullable = true,
-		references_table = nil,
-		index_flag = false,
-
-		required = function(self, msg)
-			self.required = true
-			self.nullable = false
-			self.required_msg = msg
-			return self
-		end,
-
-		default = function(self, value)
-			self.default = value
-			return self
-		end,
-
-		enum = function(self, values)
-			self.enum = values
-			return self
-		end,
-
-		-- Schema modifiers
-		primary = function(self)
-			self.primary = true
-			self.nullable = false
-			return self
-		end,
-
-		auto = function(self)
-			self.auto = true
-			return self
-		end,
-
-		unique = function(self)
-			self.unique = true
-			return self
-		end,
-
-		nullable = function(self)
-			self.nullable = true
-			self.required = false
-			return self
-		end,
-
-		references = function(self, table_col)
-			self.references_table = table_col
-			return self
-		end,
-
-		index = function(self)
-			self.index_flag = true
-			return self
-		end,
+		_primary = false,
+		_auto = false,
+		_unique = false,
+		_nullable = true,
+		_references_table = nil,
+		_index_flag = false,
 	}
+	setmetatable(v, ValidatorMT)
+	return v
 end
 
 function Guard:string()

--- a/rover-core/src/guard.lua
+++ b/rover-core/src/guard.lua
@@ -11,9 +11,17 @@ local function create_validator(validator_type)
 		enum = nil,
 		element = nil,
 		schema = nil,
+		-- Schema/migration modifiers
+		primary = false,
+		auto = false,
+		unique = false,
+		nullable = true,
+		references_table = nil,
+		index_flag = false,
 
 		required = function(self, msg)
 			self.required = true
+			self.nullable = false
 			self.required_msg = msg
 			return self
 		end,
@@ -25,6 +33,39 @@ local function create_validator(validator_type)
 
 		enum = function(self, values)
 			self.enum = values
+			return self
+		end,
+
+		-- Schema modifiers
+		primary = function(self)
+			self.primary = true
+			self.nullable = false
+			return self
+		end,
+
+		auto = function(self)
+			self.auto = true
+			return self
+		end,
+
+		unique = function(self)
+			self.unique = true
+			return self
+		end,
+
+		nullable = function(self)
+			self.nullable = true
+			self.required = false
+			return self
+		end,
+
+		references = function(self, table_col)
+			self.references_table = table_col
+			return self
+		end,
+
+		index = function(self)
+			self.index_flag = true
 			return self
 		end,
 	}

--- a/rover-core/src/lib.rs
+++ b/rover-core/src/lib.rs
@@ -99,88 +99,11 @@ pub fn run(path: &str, verbose: bool) -> Result<()> {
     let io_module = io::create_io_module(&lua)?;
     lua.globals().set("io", io_module)?;
 
-    // Create/extend debug global with print function
-    let debug_print_code = r#"
-        local debug = debug or {}
-        debug.print = function(value, label)
-            -- Format value with indentation
-            local function format_val(v, depth, seen)
-                depth = depth or 0
-                seen = seen or {}
-                
-                if depth > 5 then
-                    return "<max_depth>"
-                end
-                
-                local t = type(v)
-                if t == "nil" then
-                    return "nil"
-                elseif t == "boolean" then
-                    return tostring(v)
-                elseif t == "number" then
-                    return tostring(v)
-                elseif t == "string" then
-                    return '"' .. v:gsub('"', '\\"') .. '"'
-                elseif t == "table" then
-                    -- Check for circular reference
-                    if seen[v] then
-                        return "<circular>"
-                    end
-                    seen[v] = true
-                    
-                    local indent = string.rep("  ", depth)
-                    local next_indent = string.rep("  ", depth + 1)
-                    local lines = {"{"}
-                    
-                    -- Check if array-like
-                    local is_array = true
-                    local max_idx = 0
-                    for k in pairs(v) do
-                        if type(k) == "number" then
-                            if k > 0 then max_idx = math.max(max_idx, k) end
-                        else
-                            is_array = false
-                        end
-                    end
-                    
-                    if is_array and max_idx > 0 then
-                        -- Array format
-                        for i = 1, max_idx do
-                            if v[i] ~= nil then
-                                table.insert(lines, next_indent .. format_val(v[i], depth + 1, seen) .. ",")
-                            end
-                        end
-                    else
-                        -- Key-value format
-                        for k, val in pairs(v) do
-                            local key_str = type(k) == "string" and k or tostring(k)
-                            table.insert(lines, next_indent .. key_str .. " = " .. format_val(val, depth + 1, seen) .. ",")
-                        end
-                    end
-                    
-                    table.insert(lines, indent .. "}")
-                    return table.concat(lines, "\n")
-                else
-                    return "<" .. t .. ">"
-                end
-            end
-            
-            local formatted = format_val(value)
-            local output
-            if label then
-                output = string.format("[debug.print] %s: %s", label, formatted)
-            else
-                output = string.format("[debug.print] %s", formatted)
-            end
-            
-            print(output)
-            return value
-        end
-        
-        return debug
-    "#;
-
-    let debug_module: Table = lua.load(debug_print_code).eval()?;
+    // Load debug module from embedded Lua file
+    let debug_module: Table = lua
+        .load(include_str!("debug.lua"))
+        .set_name("debug.lua")
+        .eval()?;
     lua.globals().set("debug", debug_module)?;
 
     // Add HTTP client module

--- a/rover-core/src/lib.rs
+++ b/rover-core/src/lib.rs
@@ -9,6 +9,7 @@ mod server;
 pub mod template;
 
 use html::create_html_module;
+use rover_db::create_db_module;
 use server::{AppServer, Server};
 
 use anyhow::Result;
@@ -105,6 +106,10 @@ pub fn run(path: &str, verbose: bool) -> Result<()> {
     // Add rover.html global templating function
     let html_module = create_html_module(&lua)?;
     rover.set("html", html_module)?;
+
+    // Add rover.db database module
+    let db_module = create_db_module(&lua)?;
+    rover.set("db", db_module)?;
 
     let _ = lua.globals().set("rover", rover);
 

--- a/rover-db/Cargo.toml
+++ b/rover-db/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rover_db"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mlua = { version = "0.11.5", features = ["anyhow", "vendored", "luajit52", "send", "serialize"] }
+libsql = "0.6"
+tokio = { version = "1", features = ["rt", "sync"] }
+serde_json = "1.0"
+anyhow = "1.0"
+thiserror = "2.0"
+
+[dev-dependencies]
+tempfile = "3.8"
+
+[lib]
+bench = false

--- a/rover-db/Cargo.toml
+++ b/rover-db/Cargo.toml
@@ -10,6 +10,9 @@ tokio = { version = "1", features = ["rt", "sync"] }
 serde_json = "1.0"
 anyhow = "1.0"
 thiserror = "2.0"
+tree-sitter = "0.26.3"
+tree-sitter-lua = "0.2.0"
+rover-parser = { path = "../rover-parser" }
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/rover-db/Cargo.toml
+++ b/rover-db/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = "2.0"
 tree-sitter = "0.26.3"
 tree-sitter-lua = "0.2.0"
 rover-parser = { path = "../rover-parser" }
+chrono = "0.4"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/rover-db/src/analyzer.lua
+++ b/rover-db/src/analyzer.lua
@@ -1,0 +1,120 @@
+-- Code Analysis Engine
+-- Scans Lua code to find db.* operations and infer schema
+
+local Analyzer = {}
+
+-- Infer Lua type from value
+local function infer_type(value)
+    if type(value) == "string" then
+        return "text"
+    elseif type(value) == "number" then
+        if math.floor(value) == value then
+            return "integer"
+        else
+            return "real"
+        end
+    elseif type(value) == "boolean" then
+        return "integer" -- SQLite stores booleans as 0/1
+    elseif value == nil then
+        return "text" -- Default fallback
+    else
+        return "text"
+    end
+end
+
+-- Extract table name and fields from db.<table>:insert({...})
+local function analyze_insert_call(line)
+    -- Pattern: db.<table>:insert({ ... })
+    local table_name = line:match("db%.(%w+)%s*:%s*insert%s*%(%s*{")
+    if not table_name then
+        return nil
+    end
+
+    -- Extract the table definition (simplified - doesn't handle nested tables)
+    local start_pos = line:find("{", line:find(":insert"))
+    if not start_pos then
+        return nil
+    end
+
+    local fields = {}
+    -- Match key = value patterns
+    for key, value_str in line:gmatch("(%w+)%s*=%s*([^,}]+)") do
+        -- Try to parse value
+        if value_str:match("^['\"]") then
+            fields[key] = "text"
+        elseif value_str:match("^%d+%.%d+") then
+            fields[key] = "real"
+        elseif value_str:match("^%d+$") then
+            fields[key] = "integer"
+        elseif value_str:match("^true$") or value_str:match("^false$") then
+            fields[key] = "integer"
+        else
+            -- Reference to variable, assume text unless we can infer better
+            fields[key] = "text"
+        end
+    end
+
+    return {
+        table = table_name,
+        fields = fields,
+    }
+end
+
+-- Analyze all Lua code (simple line-by-line scan)
+function Analyzer.analyze_code(code)
+    local tables = {}
+
+    for line in code:gmatch("[^\n]+") do
+        -- Skip comments
+        if not line:match("^%s*%-%-") then
+            -- Check for db.* operations
+            if line:find("db%.%w+%s*:%s*insert") then
+                local result = analyze_insert_call(line)
+                if result then
+                    if not tables[result.table] then
+                        tables[result.table] = {}
+                    end
+                    -- Merge fields
+                    for field_name, field_type in pairs(result.fields) do
+                        if tables[result.table][field_name] then
+                            -- Type already exists, verify compatibility
+                            if tables[result.table][field_name] ~= field_type then
+                                -- Type mismatch - will be caught during validation
+                            end
+                        else
+                            tables[result.table][field_name] = field_type
+                        end
+                    end
+                end
+            end
+
+            -- Check for db.* find/update/delete to infer referenced tables
+            if line:find("db%.%w+%s*:%s*find") or
+               line:find("db%.%w+%s*:%s*update") or
+               line:find("db%.%w+%s*:%s*delete") then
+                local table_name = line:match("db%.(%w+)%s*:")
+                if table_name and not tables[table_name] then
+                    tables[table_name] = {}
+                end
+            end
+        end
+    end
+
+    return tables
+end
+
+-- Analyze directory recursively for all .lua files
+function Analyzer.analyze_directory(directory)
+    local all_tables = {}
+
+    -- Helper to read files (stub - actual implementation uses io module)
+    local function scan_dir(dir)
+        -- This would be implemented in Rust to handle dir traversal
+        -- For now, return empty
+        return {}
+    end
+
+    return all_tables
+end
+
+return Analyzer

--- a/rover-db/src/connection.rs
+++ b/rover-db/src/connection.rs
@@ -143,7 +143,8 @@ impl Connection {
 
     /// Get the last inserted row ID
     pub fn last_insert_rowid(&self) -> i64 {
-        self.runtime.block_on(async { self.conn.last_insert_rowid() })
+        self.runtime
+            .block_on(async { self.conn.last_insert_rowid() })
     }
 
     /// Check if a table exists
@@ -157,10 +158,7 @@ impl Connection {
     }
 
     /// Get table schema (column info)
-    pub fn get_table_schema(
-        &self,
-        table_name: &str,
-    ) -> Result<Vec<ColumnInfo>, ConnectionError> {
+    pub fn get_table_schema(&self, table_name: &str) -> Result<Vec<ColumnInfo>, ConnectionError> {
         let sql = format!("PRAGMA table_info({})", table_name);
         let rows = self.query(&sql)?;
 

--- a/rover-db/src/connection.rs
+++ b/rover-db/src/connection.rs
@@ -1,0 +1,268 @@
+//! Database connection management using libsql
+//!
+//! Handles SQLite connections with support for both local files and in-memory databases.
+
+use libsql::{Builder, Database};
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::runtime::Runtime;
+
+#[derive(Error, Debug)]
+pub enum ConnectionError {
+    #[error("Database error: {0}")]
+    Database(String),
+    #[error("Query error: {0}")]
+    Query(String),
+    #[error("Runtime error: {0}")]
+    Runtime(String),
+}
+
+/// Represents a database connection
+pub struct Connection {
+    db: Database,
+    conn: libsql::Connection,
+    runtime: Arc<Runtime>,
+}
+
+impl Connection {
+    /// Create a new connection to the database
+    pub fn new(path: &str) -> Result<Self, ConnectionError> {
+        // Create a tokio runtime for async operations
+        let runtime = Runtime::new().map_err(|e| ConnectionError::Runtime(e.to_string()))?;
+
+        let (db, conn) = runtime.block_on(async {
+            let db = if path == ":memory:" {
+                Builder::new_local(":memory:")
+                    .build()
+                    .await
+                    .map_err(|e| ConnectionError::Database(e.to_string()))?
+            } else {
+                Builder::new_local(path)
+                    .build()
+                    .await
+                    .map_err(|e| ConnectionError::Database(e.to_string()))?
+            };
+
+            let conn = db
+                .connect()
+                .map_err(|e| ConnectionError::Database(e.to_string()))?;
+
+            Ok::<_, ConnectionError>((db, conn))
+        })?;
+
+        Ok(Self {
+            db,
+            conn,
+            runtime: Arc::new(runtime),
+        })
+    }
+
+    /// Execute a SQL statement that doesn't return rows (INSERT, UPDATE, DELETE, CREATE)
+    pub fn execute(&self, sql: &str) -> Result<u64, ConnectionError> {
+        self.runtime.block_on(async {
+            self.conn
+                .execute(sql, ())
+                .await
+                .map_err(|e| ConnectionError::Query(e.to_string()))
+        })
+    }
+
+    /// Execute a SQL query and return rows
+    pub fn query(&self, sql: &str) -> Result<Vec<Vec<(String, libsql::Value)>>, ConnectionError> {
+        self.runtime.block_on(async {
+            let mut rows = self
+                .conn
+                .query(sql, ())
+                .await
+                .map_err(|e| ConnectionError::Query(e.to_string()))?;
+
+            let mut results = Vec::new();
+
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| ConnectionError::Query(e.to_string()))?
+            {
+                let column_count = rows.column_count();
+                let mut row_data = Vec::new();
+
+                for i in 0..column_count {
+                    let col_name = rows
+                        .column_name(i)
+                        .unwrap_or(&format!("col_{}", i))
+                        .to_string();
+                    let value = row.get_value(i as i32).unwrap_or(libsql::Value::Null);
+                    row_data.push((col_name, value));
+                }
+
+                results.push(row_data);
+            }
+
+            Ok(results)
+        })
+    }
+
+    /// Execute a SQL query with parameters
+    pub fn query_with_params(
+        &self,
+        sql: &str,
+        params: Vec<libsql::Value>,
+    ) -> Result<Vec<Vec<(String, libsql::Value)>>, ConnectionError> {
+        self.runtime.block_on(async {
+            let mut rows = self
+                .conn
+                .query(sql, params)
+                .await
+                .map_err(|e| ConnectionError::Query(e.to_string()))?;
+
+            let mut results = Vec::new();
+
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| ConnectionError::Query(e.to_string()))?
+            {
+                let column_count = rows.column_count();
+                let mut row_data = Vec::new();
+
+                for i in 0..column_count {
+                    let col_name = rows
+                        .column_name(i)
+                        .unwrap_or(&format!("col_{}", i))
+                        .to_string();
+                    let value = row.get_value(i as i32).unwrap_or(libsql::Value::Null);
+                    row_data.push((col_name, value));
+                }
+
+                results.push(row_data);
+            }
+
+            Ok(results)
+        })
+    }
+
+    /// Get the last inserted row ID
+    pub fn last_insert_rowid(&self) -> i64 {
+        self.runtime.block_on(async { self.conn.last_insert_rowid() })
+    }
+
+    /// Check if a table exists
+    pub fn table_exists(&self, table_name: &str) -> Result<bool, ConnectionError> {
+        let sql = format!(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='{}'",
+            table_name.replace('\'', "''")
+        );
+        let rows = self.query(&sql)?;
+        Ok(!rows.is_empty())
+    }
+
+    /// Get table schema (column info)
+    pub fn get_table_schema(
+        &self,
+        table_name: &str,
+    ) -> Result<Vec<ColumnInfo>, ConnectionError> {
+        let sql = format!("PRAGMA table_info({})", table_name);
+        let rows = self.query(&sql)?;
+
+        let mut columns = Vec::new();
+        for row in rows {
+            let mut col_info = ColumnInfo::default();
+
+            for (name, value) in row {
+                match name.as_str() {
+                    "name" => {
+                        if let libsql::Value::Text(s) = value {
+                            col_info.name = s;
+                        }
+                    }
+                    "type" => {
+                        if let libsql::Value::Text(s) = value {
+                            col_info.column_type = s;
+                        }
+                    }
+                    "notnull" => {
+                        col_info.not_null = matches!(value, libsql::Value::Integer(1));
+                    }
+                    "pk" => {
+                        col_info.primary_key = matches!(value, libsql::Value::Integer(1));
+                    }
+                    "dflt_value" => {
+                        if let libsql::Value::Text(s) = value {
+                            col_info.default_value = Some(s);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            columns.push(col_info);
+        }
+
+        Ok(columns)
+    }
+}
+
+/// Information about a database column
+#[derive(Debug, Default, Clone)]
+pub struct ColumnInfo {
+    pub name: String,
+    pub column_type: String,
+    pub not_null: bool,
+    pub primary_key: bool,
+    pub default_value: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_memory_connection() {
+        let conn = Connection::new(":memory:").unwrap();
+
+        // Create a test table
+        conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
+            .unwrap();
+
+        // Insert data
+        conn.execute("INSERT INTO test (name) VALUES ('hello')")
+            .unwrap();
+
+        // Query data
+        let rows = conn.query("SELECT * FROM test").unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn test_table_exists() {
+        let conn = Connection::new(":memory:").unwrap();
+
+        assert!(!conn.table_exists("test").unwrap());
+
+        conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        assert!(conn.table_exists("test").unwrap());
+    }
+
+    #[test]
+    fn test_get_table_schema() {
+        let conn = Connection::new(":memory:").unwrap();
+
+        conn.execute(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, age INTEGER)",
+        )
+        .unwrap();
+
+        let schema = conn.get_table_schema("users").unwrap();
+        assert_eq!(schema.len(), 3);
+
+        assert_eq!(schema[0].name, "id");
+        assert!(schema[0].primary_key);
+
+        assert_eq!(schema[1].name, "name");
+        assert!(schema[1].not_null);
+
+        assert_eq!(schema[2].name, "age");
+    }
+}

--- a/rover-db/src/db.lua
+++ b/rover-db/src/db.lua
@@ -1,0 +1,1020 @@
+-- Rover DB - Intent-Based Query Builder & ORM DSL
+-- Code expresses WHAT you want, Rover decides HOW to execute
+
+local DB = {}
+
+-- ============================================================================
+-- Internal: Deep copy utility
+-- ============================================================================
+local function deep_copy(obj, seen)
+    if type(obj) ~= "table" then
+        return obj
+    end
+    seen = seen or {}
+    if seen[obj] then
+        return seen[obj]
+    end
+    local copy = {}
+    seen[obj] = copy
+    for k, v in pairs(obj) do
+        copy[deep_copy(k, seen)] = deep_copy(v, seen)
+    end
+    setmetatable(copy, getmetatable(obj))
+    return copy
+end
+
+-- ============================================================================
+-- ColumnRef: Reference to a column (db.users.id)
+-- ============================================================================
+local ColumnRef = {}
+ColumnRef.__index = ColumnRef
+
+function ColumnRef.new(table_name, column_name)
+    local self = setmetatable({}, ColumnRef)
+    self._type = "column_ref"
+    self._table = table_name
+    self._column = column_name
+    return self
+end
+
+function ColumnRef:__tostring()
+    return self._table .. "." .. self._column
+end
+
+-- ============================================================================
+-- TableProxy: Proxy for dynamic table access (db.users)
+-- ============================================================================
+local TableProxy = {}
+
+local function create_table_proxy(db_instance, table_name)
+    local proxy = {
+        _type = "table_proxy",
+        _name = table_name,
+        _db = db_instance,
+    }
+
+    local mt = {
+        -- db.users.id -> ColumnRef
+        __index = function(_, column_name)
+            return ColumnRef.new(table_name, column_name)
+        end,
+
+        __tostring = function()
+            return "TableProxy(" .. table_name .. ")"
+        end,
+    }
+
+    setmetatable(proxy, mt)
+
+    -- Add methods directly to proxy (not through metatable to avoid conflicts)
+    proxy.find = function(_)
+        return DB._create_query(db_instance, table_name)
+    end
+
+    proxy.insert = function(_, data)
+        return DB._insert(db_instance, table_name, data)
+    end
+
+    proxy.update = function(_)
+        return DB._create_update_query(db_instance, table_name)
+    end
+
+    proxy.delete = function(_)
+        return DB._create_delete_query(db_instance, table_name)
+    end
+
+    proxy.sql = function(_)
+        return DB._create_raw_query(db_instance, table_name)
+    end
+
+    return proxy
+end
+
+-- ============================================================================
+-- Query: Immutable query object representing intent
+-- ============================================================================
+local Query = {}
+Query.__index = Query
+
+function Query.new(db_instance, table_name)
+    local self = setmetatable({}, Query)
+    self._type = "query"
+    self._db = db_instance
+    self._table = table_name
+    self._filters = {}
+    self._exists_clauses = {}
+    self._merged_queries = {}
+    self._group_by_cols = {}
+    self._aggregates = {}
+    self._having_filters = {}
+    self._order_by = {}
+    self._limit_val = nil
+    self._offset_val = nil
+    self._preloads = {}
+    self._select_cols = nil -- nil means SELECT *
+    return self
+end
+
+-- Clone to maintain immutability
+function Query:_clone()
+    return deep_copy(self)
+end
+
+-- ============================================================================
+-- Query: Semantic Filters (by_<field>_<operator>)
+-- ============================================================================
+
+-- Operators mapping
+local OPERATORS = {
+    equals = "=",
+    not_equals = "!=",
+    bigger_than = ">",
+    smaller_than = "<",
+    bigger_than_or_equals = ">=",
+    smaller_than_or_equals = "<=",
+    contains = "LIKE",
+    starts_with = "LIKE",
+    ends_with = "LIKE",
+    between = "BETWEEN",
+    in_list = "IN",
+    not_in_list = "NOT IN",
+    is_null = "IS NULL",
+    is_not_null = "IS NOT NULL",
+}
+
+-- Parse filter method name: by_<field>_<operator> or by_<field> (equals)
+local function parse_filter_method(method_name)
+    if not method_name:match("^by_") then
+        return nil, nil
+    end
+
+    local rest = method_name:sub(4) -- Remove "by_"
+
+    -- Try to match known operators from longest to shortest
+    local ops_by_length = {}
+    for op in pairs(OPERATORS) do
+        table.insert(ops_by_length, op)
+    end
+    table.sort(ops_by_length, function(a, b)
+        return #a > #b
+    end)
+
+    for _, op in ipairs(ops_by_length) do
+        local pattern = "_" .. op .. "$"
+        if rest:match(pattern) then
+            local field = rest:sub(1, -(#op + 2)) -- Remove _<operator>
+            return field, op
+        end
+    end
+
+    -- No operator found, default to "equals"
+    return rest, "equals"
+end
+
+-- Parse having filter: having_<agg>_<op> (e.g., having_count_bigger_than)
+local function parse_having_method(method_name)
+    if not method_name:match("^having_") then
+        return nil, nil
+    end
+
+    local rest = method_name:sub(8) -- Remove "having_"
+
+    -- Try to match known operators
+    local ops_by_length = {}
+    for op in pairs(OPERATORS) do
+        table.insert(ops_by_length, op)
+    end
+    table.sort(ops_by_length, function(a, b)
+        return #a > #b
+    end)
+
+    for _, op in ipairs(ops_by_length) do
+        local pattern = "_" .. op .. "$"
+        if rest:match(pattern) then
+            local agg_name = rest:sub(1, -(#op + 2))
+            return agg_name, op
+        end
+    end
+
+    return nil, nil
+end
+
+-- Parse with_* for preloads: with_user -> "user"
+local function parse_preload_method(method_name)
+    if method_name:match("^with_") then
+        return method_name:sub(6)
+    end
+    return nil
+end
+
+-- Dynamic method handler for Query
+local query_mt = {
+    __index = function(self, key)
+        -- Check for existing methods first
+        if Query[key] then
+            return Query[key]
+        end
+
+        -- Check for by_<field>_<operator> pattern
+        local field, operator = parse_filter_method(key)
+        if field then
+            return function(_, value)
+                local new_query = self:_clone()
+                table.insert(new_query._filters, {
+                    field = field,
+                    operator = operator,
+                    value = value,
+                })
+                return new_query
+            end
+        end
+
+        -- Check for having_<agg>_<op> pattern
+        local agg_name, having_op = parse_having_method(key)
+        if agg_name then
+            return function(_, value)
+                local new_query = self:_clone()
+                table.insert(new_query._having_filters, {
+                    aggregate = agg_name,
+                    operator = having_op,
+                    value = value,
+                })
+                return new_query
+            end
+        end
+
+        -- Check for with_<relation> pattern (preloads)
+        local relation = parse_preload_method(key)
+        if relation then
+            return function(_)
+                local new_query = self:_clone()
+                table.insert(new_query._preloads, relation)
+                return new_query
+            end
+        end
+
+        return nil
+    end,
+
+    __tostring = function(self)
+        return "Query(" .. self._table .. ")"
+    end,
+}
+
+function Query.new_with_mt(db_instance, table_name)
+    local self = Query.new(db_instance, table_name)
+    setmetatable(self, query_mt)
+    return self
+end
+
+-- ============================================================================
+-- Query: EXISTS (Correlated Subqueries)
+-- ============================================================================
+
+function Query:exists(subquery)
+    local new_query = self:_clone()
+    -- Store the subquery, correlation will be added via :on()
+    new_query._pending_exists = subquery
+    return new_query
+end
+
+function Query:on(col_a, col_b)
+    local new_query = self:_clone()
+    if new_query._pending_exists then
+        table.insert(new_query._exists_clauses, {
+            subquery = new_query._pending_exists,
+            correlation = { col_a, col_b },
+        })
+        new_query._pending_exists = nil
+    end
+    return new_query
+end
+
+-- ============================================================================
+-- Query: select() for subquery projections
+-- ============================================================================
+
+function Query:select(...)
+    local new_query = self:_clone()
+    local cols = { ... }
+    new_query._select_cols = cols
+    return new_query
+end
+
+-- ============================================================================
+-- Query: OR via merge (Query Composition)
+-- ============================================================================
+
+function Query:merge(...)
+    local new_query = self:_clone()
+    local queries = { ... }
+    for _, q in ipairs(queries) do
+        table.insert(new_query._merged_queries, q)
+    end
+    return new_query
+end
+
+-- Alias for merge
+Query.any_of = Query.merge
+
+-- ============================================================================
+-- Query: Grouping & Aggregates
+-- ============================================================================
+
+function Query:group_by(...)
+    local new_query = self:_clone()
+    local cols = { ... }
+    for _, col in ipairs(cols) do
+        table.insert(new_query._group_by_cols, col)
+    end
+    return new_query
+end
+
+function Query:agg(aggregates)
+    local new_query = self:_clone()
+    new_query._aggregates = aggregates
+    return new_query
+end
+
+-- ============================================================================
+-- Query: Ordering, Limit, Offset
+-- ============================================================================
+
+function Query:order_by(col, direction)
+    local new_query = self:_clone()
+    direction = direction or "ASC"
+    table.insert(new_query._order_by, { col = col, direction = direction })
+    return new_query
+end
+
+function Query:limit(n)
+    local new_query = self:_clone()
+    new_query._limit_val = n
+    return new_query
+end
+
+function Query:offset(n)
+    local new_query = self:_clone()
+    new_query._offset_val = n
+    return new_query
+end
+
+-- ============================================================================
+-- Query: Execution Methods
+-- ============================================================================
+
+function Query:all()
+    return DB._execute_query(self._db, self, "all")
+end
+
+function Query:first()
+    local limited = self:limit(1)
+    local results = DB._execute_query(self._db, limited, "first")
+    if results and #results > 0 then
+        return results[1]
+    end
+    return nil
+end
+
+function Query:count()
+    return DB._execute_query(self._db, self, "count")
+end
+
+-- ============================================================================
+-- Query: Inspection
+-- ============================================================================
+
+function Query:inspect()
+    local info = {
+        intent = "SELECT",
+        table = self._table,
+        filters = {},
+        exists_clauses = {},
+        merged_queries = {},
+        group_by = {},
+        aggregates = {},
+        having = {},
+        order_by = self._order_by,
+        limit = self._limit_val,
+        offset = self._offset_val,
+        preloads = self._preloads,
+    }
+
+    -- Format filters
+    for _, f in ipairs(self._filters) do
+        table.insert(info.filters, {
+            field = f.field,
+            operator = f.operator,
+            value = f.value,
+        })
+    end
+
+    -- Format exists clauses
+    for _, e in ipairs(self._exists_clauses) do
+        local subquery_info = e.subquery:inspect()
+        table.insert(info.exists_clauses, {
+            subquery = subquery_info,
+            correlation = {
+                tostring(e.correlation[1]),
+                tostring(e.correlation[2]),
+            },
+        })
+    end
+
+    -- Format merged queries
+    for _, mq in ipairs(self._merged_queries) do
+        table.insert(info.merged_queries, mq:inspect())
+    end
+
+    -- Format group by
+    for _, col in ipairs(self._group_by_cols) do
+        table.insert(info.group_by, tostring(col))
+    end
+
+    -- Format aggregates
+    for name, agg in pairs(self._aggregates) do
+        info.aggregates[name] = tostring(agg)
+    end
+
+    -- Format having
+    for _, h in ipairs(self._having_filters) do
+        table.insert(info.having, {
+            aggregate = h.aggregate,
+            operator = h.operator,
+            value = h.value,
+        })
+    end
+
+    -- Generate candidate SQL
+    info.candidate_sql = DB._generate_sql(self)
+
+    -- Lowering strategy hints
+    info.lowering_strategy = DB._determine_strategy(self)
+
+    return info
+end
+
+-- ============================================================================
+-- UpdateQuery: For update operations
+-- ============================================================================
+
+local UpdateQuery = {}
+UpdateQuery.__index = UpdateQuery
+
+function UpdateQuery.new(db_instance, table_name)
+    local self = setmetatable({}, UpdateQuery)
+    self._type = "update_query"
+    self._db = db_instance
+    self._table = table_name
+    self._filters = {}
+    self._set_values = {}
+    return self
+end
+
+function UpdateQuery:_clone()
+    return deep_copy(self)
+end
+
+function UpdateQuery:set(values)
+    local new_query = self:_clone()
+    for k, v in pairs(values) do
+        new_query._set_values[k] = v
+    end
+    return new_query
+end
+
+function UpdateQuery:exec()
+    return DB._execute_update(self._db, self)
+end
+
+-- Dynamic filter methods for UpdateQuery
+local update_query_mt = {
+    __index = function(self, key)
+        if UpdateQuery[key] then
+            return UpdateQuery[key]
+        end
+
+        local field, operator = parse_filter_method(key)
+        if field then
+            return function(_, value)
+                local new_query = self:_clone()
+                table.insert(new_query._filters, {
+                    field = field,
+                    operator = operator,
+                    value = value,
+                })
+                return new_query
+            end
+        end
+
+        return nil
+    end,
+}
+
+function UpdateQuery.new_with_mt(db_instance, table_name)
+    local self = UpdateQuery.new(db_instance, table_name)
+    setmetatable(self, update_query_mt)
+    return self
+end
+
+-- ============================================================================
+-- DeleteQuery: For delete operations
+-- ============================================================================
+
+local DeleteQuery = {}
+DeleteQuery.__index = DeleteQuery
+
+function DeleteQuery.new(db_instance, table_name)
+    local self = setmetatable({}, DeleteQuery)
+    self._type = "delete_query"
+    self._db = db_instance
+    self._table = table_name
+    self._filters = {}
+    return self
+end
+
+function DeleteQuery:_clone()
+    return deep_copy(self)
+end
+
+function DeleteQuery:exec()
+    return DB._execute_delete(self._db, self)
+end
+
+-- Dynamic filter methods for DeleteQuery
+local delete_query_mt = {
+    __index = function(self, key)
+        if DeleteQuery[key] then
+            return DeleteQuery[key]
+        end
+
+        local field, operator = parse_filter_method(key)
+        if field then
+            return function(_, value)
+                local new_query = self:_clone()
+                table.insert(new_query._filters, {
+                    field = field,
+                    operator = operator,
+                    value = value,
+                })
+                return new_query
+            end
+        end
+
+        return nil
+    end,
+}
+
+function DeleteQuery.new_with_mt(db_instance, table_name)
+    local self = DeleteQuery.new(db_instance, table_name)
+    setmetatable(self, delete_query_mt)
+    return self
+end
+
+-- ============================================================================
+-- RawQuery: For SQL escape hatch
+-- ============================================================================
+
+local RawQuery = {}
+RawQuery.__index = RawQuery
+
+function RawQuery.new(db_instance, table_name)
+    local self = setmetatable({}, RawQuery)
+    self._type = "raw_query"
+    self._db = db_instance
+    self._table = table_name
+    self._sql = nil
+    self._params = {}
+    return self
+end
+
+function RawQuery:raw(sql, params)
+    local new_query = setmetatable({}, RawQuery)
+    new_query._type = "raw_query"
+    new_query._db = self._db
+    new_query._table = self._table
+    new_query._sql = sql
+    new_query._params = params or {}
+    return new_query
+end
+
+function RawQuery:exec()
+    return DB._execute_raw(self._db, self)
+end
+
+function RawQuery:all()
+    return DB._execute_raw(self._db, self)
+end
+
+function RawQuery:inspect()
+    return {
+        intent = "RAW SQL",
+        sql = self._sql,
+        params = self._params,
+    }
+end
+
+-- ============================================================================
+-- Aggregate Functions
+-- ============================================================================
+
+local AggregateExpr = {}
+AggregateExpr.__index = AggregateExpr
+
+function AggregateExpr.new(func, col)
+    local self = setmetatable({}, AggregateExpr)
+    self._type = "aggregate"
+    self._func = func
+    self._col = col
+    return self
+end
+
+function AggregateExpr:__tostring()
+    return self._func .. "(" .. tostring(self._col) .. ")"
+end
+
+-- Aggregate factory functions
+function DB.sum(col)
+    return AggregateExpr.new("SUM", col)
+end
+
+function DB.count(col)
+    return AggregateExpr.new("COUNT", col)
+end
+
+function DB.avg(col)
+    return AggregateExpr.new("AVG", col)
+end
+
+function DB.min(col)
+    return AggregateExpr.new("MIN", col)
+end
+
+function DB.max(col)
+    return AggregateExpr.new("MAX", col)
+end
+
+-- ============================================================================
+-- SQL Generation (Lowering)
+-- ============================================================================
+
+local function escape_value(value)
+    if value == nil then
+        return "NULL"
+    elseif type(value) == "string" then
+        -- Simple escaping - in production, use prepared statements
+        return "'" .. value:gsub("'", "''") .. "'"
+    elseif type(value) == "number" then
+        return tostring(value)
+    elseif type(value) == "boolean" then
+        return value and "1" or "0"
+    elseif type(value) == "table" then
+        if value._type == "query" then
+            -- Subquery
+            return "(" .. DB._generate_sql(value) .. ")"
+        elseif value._type == "column_ref" then
+            return value._table .. "." .. value._column
+        else
+            -- Array for IN clause
+            local items = {}
+            for _, v in ipairs(value) do
+                table.insert(items, escape_value(v))
+            end
+            return "(" .. table.concat(items, ", ") .. ")"
+        end
+    end
+    return "NULL"
+end
+
+local function generate_filter_sql(filter)
+    local field = filter.field
+    local op = filter.operator
+    local value = filter.value
+    local sql_op = OPERATORS[op]
+
+    if op == "is_null" or op == "is_not_null" then
+        return field .. " " .. sql_op
+    elseif op == "contains" then
+        return field .. " LIKE '%" .. value:gsub("'", "''") .. "%'"
+    elseif op == "starts_with" then
+        return field .. " LIKE '" .. value:gsub("'", "''") .. "%'"
+    elseif op == "ends_with" then
+        return field .. " LIKE '%" .. value:gsub("'", "''") .. "'"
+    elseif op == "between" then
+        return field .. " BETWEEN " .. escape_value(value[1]) .. " AND " .. escape_value(value[2])
+    elseif op == "in_list" or op == "not_in_list" then
+        return field .. " " .. sql_op .. " " .. escape_value(value)
+    else
+        return field .. " " .. sql_op .. " " .. escape_value(value)
+    end
+end
+
+function DB._generate_sql(query)
+    if query._type == "raw_query" then
+        return query._sql
+    end
+
+    local parts = {}
+
+    -- SELECT clause
+    if query._aggregates and next(query._aggregates) then
+        local select_parts = {}
+        for name, agg in pairs(query._aggregates) do
+            table.insert(select_parts, tostring(agg) .. " AS " .. name)
+        end
+        -- Add group by columns to select
+        for _, col in ipairs(query._group_by_cols) do
+            table.insert(select_parts, tostring(col))
+        end
+        table.insert(parts, "SELECT " .. table.concat(select_parts, ", "))
+    elseif query._select_cols then
+        local cols = {}
+        for _, col in ipairs(query._select_cols) do
+            table.insert(cols, tostring(col))
+        end
+        table.insert(parts, "SELECT " .. table.concat(cols, ", "))
+    else
+        table.insert(parts, "SELECT *")
+    end
+
+    -- FROM clause
+    table.insert(parts, "FROM " .. query._table)
+
+    -- WHERE clause
+    local where_conditions = {}
+
+    -- Regular filters
+    for _, filter in ipairs(query._filters) do
+        table.insert(where_conditions, generate_filter_sql(filter))
+    end
+
+    -- EXISTS clauses
+    for _, exists_clause in ipairs(query._exists_clauses) do
+        local subquery = exists_clause.subquery
+        local corr = exists_clause.correlation
+        -- Add correlation to subquery filters
+        local corr_filter =
+            tostring(corr[1]) .. " = " .. tostring(corr[2])
+        local subquery_sql = DB._generate_sql(subquery)
+        -- Insert correlation into WHERE of subquery
+        if subquery_sql:find("WHERE") then
+            subquery_sql = subquery_sql:gsub("WHERE", "WHERE " .. corr_filter .. " AND")
+        else
+            subquery_sql = subquery_sql .. " WHERE " .. corr_filter
+        end
+        table.insert(where_conditions, "EXISTS (" .. subquery_sql .. ")")
+    end
+
+    -- Merged queries (OR)
+    if #query._merged_queries > 0 then
+        local or_parts = {}
+        for _, mq in ipairs(query._merged_queries) do
+            -- Get the WHERE part of merged query
+            local mq_conditions = {}
+            for _, filter in ipairs(mq._filters) do
+                table.insert(mq_conditions, generate_filter_sql(filter))
+            end
+            for _, exists_clause in ipairs(mq._exists_clauses) do
+                local subquery = exists_clause.subquery
+                local corr = exists_clause.correlation
+                local corr_filter = tostring(corr[1]) .. " = " .. tostring(corr[2])
+                local subquery_sql = DB._generate_sql(subquery)
+                if subquery_sql:find("WHERE") then
+                    subquery_sql = subquery_sql:gsub("WHERE", "WHERE " .. corr_filter .. " AND")
+                else
+                    subquery_sql = subquery_sql .. " WHERE " .. corr_filter
+                end
+                table.insert(mq_conditions, "EXISTS (" .. subquery_sql .. ")")
+            end
+            if #mq_conditions > 0 then
+                table.insert(or_parts, "(" .. table.concat(mq_conditions, " AND ") .. ")")
+            end
+        end
+        if #or_parts > 0 then
+            table.insert(where_conditions, "(" .. table.concat(or_parts, " OR ") .. ")")
+        end
+    end
+
+    if #where_conditions > 0 then
+        table.insert(parts, "WHERE " .. table.concat(where_conditions, " AND "))
+    end
+
+    -- GROUP BY clause
+    if #query._group_by_cols > 0 then
+        local group_cols = {}
+        for _, col in ipairs(query._group_by_cols) do
+            table.insert(group_cols, tostring(col))
+        end
+        table.insert(parts, "GROUP BY " .. table.concat(group_cols, ", "))
+    end
+
+    -- HAVING clause
+    if #query._having_filters > 0 then
+        local having_conditions = {}
+        for _, h in ipairs(query._having_filters) do
+            local agg_expr = h.aggregate
+            local sql_op = OPERATORS[h.operator]
+            table.insert(having_conditions, agg_expr .. " " .. sql_op .. " " .. escape_value(h.value))
+        end
+        table.insert(parts, "HAVING " .. table.concat(having_conditions, " AND "))
+    end
+
+    -- ORDER BY clause
+    if #query._order_by > 0 then
+        local order_parts = {}
+        for _, o in ipairs(query._order_by) do
+            table.insert(order_parts, tostring(o.col) .. " " .. o.direction)
+        end
+        table.insert(parts, "ORDER BY " .. table.concat(order_parts, ", "))
+    end
+
+    -- LIMIT and OFFSET
+    if query._limit_val then
+        table.insert(parts, "LIMIT " .. query._limit_val)
+    end
+
+    if query._offset_val then
+        table.insert(parts, "OFFSET " .. query._offset_val)
+    end
+
+    return table.concat(parts, " ")
+end
+
+function DB._determine_strategy(query)
+    local strategies = {}
+
+    if #query._exists_clauses > 0 then
+        table.insert(strategies, "EXISTS (correlated subquery)")
+    end
+
+    for _, filter in ipairs(query._filters) do
+        if filter.operator == "in_list" and type(filter.value) == "table" and filter.value._type == "query" then
+            table.insert(strategies, "IN (subquery)")
+        end
+    end
+
+    if #query._merged_queries > 0 then
+        table.insert(strategies, "OR composition")
+    end
+
+    if #query._preloads > 0 then
+        table.insert(strategies, "Preload via separate queries or JOIN (TBD at execution)")
+    end
+
+    if #strategies == 0 then
+        table.insert(strategies, "Simple query")
+    end
+
+    return strategies
+end
+
+-- ============================================================================
+-- Update SQL Generation
+-- ============================================================================
+
+function DB._generate_update_sql(query)
+    local parts = { "UPDATE " .. query._table }
+
+    -- SET clause
+    local set_parts = {}
+    for k, v in pairs(query._set_values) do
+        table.insert(set_parts, k .. " = " .. escape_value(v))
+    end
+    table.insert(parts, "SET " .. table.concat(set_parts, ", "))
+
+    -- WHERE clause
+    if #query._filters > 0 then
+        local where_conditions = {}
+        for _, filter in ipairs(query._filters) do
+            table.insert(where_conditions, generate_filter_sql(filter))
+        end
+        table.insert(parts, "WHERE " .. table.concat(where_conditions, " AND "))
+    end
+
+    return table.concat(parts, " ")
+end
+
+-- ============================================================================
+-- Delete SQL Generation
+-- ============================================================================
+
+function DB._generate_delete_sql(query)
+    local parts = { "DELETE FROM " .. query._table }
+
+    -- WHERE clause
+    if #query._filters > 0 then
+        local where_conditions = {}
+        for _, filter in ipairs(query._filters) do
+            table.insert(where_conditions, generate_filter_sql(filter))
+        end
+        table.insert(parts, "WHERE " .. table.concat(where_conditions, " AND "))
+    end
+
+    return table.concat(parts, " ")
+end
+
+-- ============================================================================
+-- Insert SQL Generation
+-- ============================================================================
+
+function DB._generate_insert_sql(table_name, data)
+    local columns = {}
+    local values = {}
+
+    for k, v in pairs(data) do
+        table.insert(columns, k)
+        table.insert(values, escape_value(v))
+    end
+
+    return "INSERT INTO "
+        .. table_name
+        .. " ("
+        .. table.concat(columns, ", ")
+        .. ") VALUES ("
+        .. table.concat(values, ", ")
+        .. ")"
+end
+
+-- ============================================================================
+-- DB Instance: Factory Methods
+-- ============================================================================
+
+function DB._create_query(db_instance, table_name)
+    return Query.new_with_mt(db_instance, table_name)
+end
+
+function DB._create_update_query(db_instance, table_name)
+    return UpdateQuery.new_with_mt(db_instance, table_name)
+end
+
+function DB._create_delete_query(db_instance, table_name)
+    return DeleteQuery.new_with_mt(db_instance, table_name)
+end
+
+function DB._create_raw_query(db_instance, table_name)
+    return RawQuery.new(db_instance, table_name)
+end
+
+-- ============================================================================
+-- DB Instance: Execution (Placeholder - Rust will override these)
+-- ============================================================================
+
+-- These functions are placeholders that will be overridden by Rust
+-- They contain the SQL generation logic for inspection
+
+function DB._insert(db_instance, table_name, data)
+    local sql = DB._generate_insert_sql(table_name, data)
+    -- The actual execution is handled by Rust
+    return db_instance._executor("insert", sql, data, table_name)
+end
+
+function DB._execute_query(db_instance, query, mode)
+    local sql = DB._generate_sql(query)
+    return db_instance._executor("query", sql, query, mode)
+end
+
+function DB._execute_update(db_instance, query)
+    local sql = DB._generate_update_sql(query)
+    return db_instance._executor("update", sql, query)
+end
+
+function DB._execute_delete(db_instance, query)
+    local sql = DB._generate_delete_sql(query)
+    return db_instance._executor("delete", sql, query)
+end
+
+function DB._execute_raw(db_instance, query)
+    return db_instance._executor("raw", query._sql, query._params)
+end
+
+-- ============================================================================
+-- DB Instance Creation
+-- ============================================================================
+
+function DB.connect(config)
+    local instance = {
+        _config = config or {},
+        _executor = nil, -- Will be set by Rust
+    }
+
+    -- Metatable for dynamic table access: db.users -> TableProxy
+    local mt = {
+        __index = function(self, key)
+            -- Check for built-in methods first
+            if DB[key] then
+                return DB[key]
+            end
+            -- Otherwise, return a table proxy
+            return create_table_proxy(self, key)
+        end,
+    }
+
+    setmetatable(instance, mt)
+    return instance
+end
+
+-- ============================================================================
+-- Module Export
+-- ============================================================================
+
+return DB

--- a/rover-db/src/db.lua
+++ b/rover-db/src/db.lua
@@ -965,7 +965,7 @@ end
 function DB._insert(db_instance, table_name, data)
     local sql = DB._generate_insert_sql(table_name, data)
     -- The actual execution is handled by Rust
-    return db_instance._executor("insert", sql, data, table_name)
+    return db_instance._executor("insert", sql, table_name, data)
 end
 
 function DB._execute_query(db_instance, query, mode)

--- a/rover-db/src/executor.rs
+++ b/rover-db/src/executor.rs
@@ -1,0 +1,268 @@
+//! Query execution engine
+//!
+//! Bridges Lua queries to actual database operations with schema inference support.
+
+use crate::connection::Connection;
+use crate::schema::SchemaManager;
+use mlua::prelude::*;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Query executor that handles all database operations
+pub struct QueryExecutor {
+    conn: Arc<Mutex<Connection>>,
+    schema_manager: SchemaManager,
+}
+
+impl QueryExecutor {
+    /// Create a new query executor
+    pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
+        Self {
+            conn: conn.clone(),
+            schema_manager: SchemaManager::new(conn),
+        }
+    }
+
+    /// Execute an INSERT operation with schema inference
+    pub fn execute_insert(
+        &self,
+        lua: &Lua,
+        sql: &str,
+        table_name: &str,
+        data: LuaValue,
+    ) -> LuaResult<LuaValue> {
+        // Extract data as a table for schema inference
+        let data_table = match &data {
+            LuaValue::Table(t) => t.clone(),
+            _ => {
+                return Err(LuaError::RuntimeError(
+                    "Insert data must be a table".to_string(),
+                ))
+            }
+        };
+
+        // Check if table exists, if not infer schema and create it
+        let conn = self
+            .conn
+            .blocking_lock();
+
+        if !table_name.is_empty() && !conn.table_exists(table_name).unwrap_or(false) {
+            // Infer schema from data
+            let schema = self
+                .schema_manager
+                .infer_schema_from_lua(&data_table)
+                .map_err(|e| LuaError::RuntimeError(e.to_string()))?;
+
+            // Generate and execute CREATE TABLE
+            let create_sql = self.schema_manager.generate_create_table(table_name, &schema);
+
+            conn.execute(&create_sql)
+                .map_err(|e| LuaError::RuntimeError(format!("Failed to create table: {}", e)))?;
+        }
+
+        // Execute the INSERT
+        conn.execute(sql)
+            .map_err(|e| LuaError::RuntimeError(format!("Insert failed: {}", e)))?;
+
+        // Return the last insert ID
+        let last_id = conn.last_insert_rowid();
+
+        // Return a table with the result
+        let result = lua.create_table()?;
+        result.set("id", last_id)?;
+        result.set("success", true)?;
+
+        Ok(LuaValue::Table(result))
+    }
+
+    /// Execute a SELECT query
+    pub fn execute_query(&self, lua: &Lua, sql: &str, mode: &str) -> LuaResult<LuaValue> {
+        let conn = self.conn.blocking_lock();
+
+        if mode == "count" {
+            // For count queries, wrap in COUNT(*)
+            let count_sql = if sql.to_uppercase().contains("SELECT *") {
+                sql.replace("SELECT *", "SELECT COUNT(*)")
+            } else {
+                format!("SELECT COUNT(*) as count FROM ({})", sql)
+            };
+
+            let rows = conn
+                .query(&count_sql)
+                .map_err(|e| LuaError::RuntimeError(format!("Query failed: {}", e)))?;
+
+            if let Some(row) = rows.first() {
+                for (_, value) in row {
+                    if let libsql::Value::Integer(count) = value {
+                        return Ok(LuaValue::Integer(*count));
+                    }
+                }
+            }
+            return Ok(LuaValue::Integer(0));
+        }
+
+        let rows = conn
+            .query(sql)
+            .map_err(|e| LuaError::RuntimeError(format!("Query failed: {}", e)))?;
+
+        // Convert rows to Lua tables
+        let results = lua.create_table()?;
+
+        for (idx, row) in rows.iter().enumerate() {
+            let row_table = lua.create_table()?;
+
+            for (col_name, value) in row {
+                let lua_value = libsql_value_to_lua(lua, value)?;
+                row_table.set(col_name.as_str(), lua_value)?;
+            }
+
+            results.set(idx + 1, row_table)?;
+        }
+
+        Ok(LuaValue::Table(results))
+    }
+
+    /// Execute an UPDATE operation
+    pub fn execute_update(&self, sql: &str) -> LuaResult<LuaValue> {
+        let conn = self.conn.blocking_lock();
+
+        let affected = conn
+            .execute(sql)
+            .map_err(|e| LuaError::RuntimeError(format!("Update failed: {}", e)))?;
+
+        Ok(LuaValue::Integer(affected as i64))
+    }
+
+    /// Execute a DELETE operation
+    pub fn execute_delete(&self, sql: &str) -> LuaResult<LuaValue> {
+        let conn = self.conn.blocking_lock();
+
+        let affected = conn
+            .execute(sql)
+            .map_err(|e| LuaError::RuntimeError(format!("Delete failed: {}", e)))?;
+
+        Ok(LuaValue::Integer(affected as i64))
+    }
+
+    /// Execute a raw SQL query
+    pub fn execute_raw(
+        &self,
+        lua: &Lua,
+        sql: &str,
+        params: Option<LuaTable>,
+    ) -> LuaResult<LuaValue> {
+        let conn = self.conn.blocking_lock();
+
+        // Convert Lua params to libsql values if provided
+        let libsql_params = if let Some(params_table) = params {
+            let mut values = Vec::new();
+            for pair in params_table.pairs::<i64, LuaValue>() {
+                if let Ok((_, value)) = pair {
+                    values.push(lua_value_to_libsql(&value)?);
+                }
+            }
+            values
+        } else {
+            Vec::new()
+        };
+
+        // Check if it's a SELECT query
+        let sql_upper = sql.trim().to_uppercase();
+        if sql_upper.starts_with("SELECT") {
+            let rows = if libsql_params.is_empty() {
+                conn.query(sql)
+            } else {
+                conn.query_with_params(sql, libsql_params)
+            }
+            .map_err(|e| LuaError::RuntimeError(format!("Query failed: {}", e)))?;
+
+            let results = lua.create_table()?;
+            for (idx, row) in rows.iter().enumerate() {
+                let row_table = lua.create_table()?;
+                for (col_name, value) in row {
+                    let lua_value = libsql_value_to_lua(lua, value)?;
+                    row_table.set(col_name.as_str(), lua_value)?;
+                }
+                results.set(idx + 1, row_table)?;
+            }
+
+            Ok(LuaValue::Table(results))
+        } else {
+            // Execute non-SELECT statement
+            let affected = conn
+                .execute(sql)
+                .map_err(|e| LuaError::RuntimeError(format!("Execution failed: {}", e)))?;
+
+            Ok(LuaValue::Integer(affected as i64))
+        }
+    }
+}
+
+/// Convert libsql Value to Lua Value
+fn libsql_value_to_lua(lua: &Lua, value: &libsql::Value) -> LuaResult<LuaValue> {
+    match value {
+        libsql::Value::Null => Ok(LuaValue::Nil),
+        libsql::Value::Integer(i) => Ok(LuaValue::Integer(*i)),
+        libsql::Value::Real(f) => Ok(LuaValue::Number(*f)),
+        libsql::Value::Text(s) => Ok(LuaValue::String(lua.create_string(s)?)),
+        libsql::Value::Blob(b) => Ok(LuaValue::String(lua.create_string(b)?)),
+    }
+}
+
+/// Convert Lua Value to libsql Value
+fn lua_value_to_libsql(value: &LuaValue) -> LuaResult<libsql::Value> {
+    match value {
+        LuaValue::Nil => Ok(libsql::Value::Null),
+        LuaValue::Integer(i) => Ok(libsql::Value::Integer(*i)),
+        LuaValue::Number(n) => Ok(libsql::Value::Real(*n)),
+        LuaValue::String(s) => Ok(libsql::Value::Text(s.to_str()?.to_string())),
+        LuaValue::Boolean(b) => Ok(libsql::Value::Integer(if *b { 1 } else { 0 })),
+        _ => Err(LuaError::RuntimeError(
+            "Unsupported Lua type for SQL parameter".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_executor_basic_operations() {
+        let conn = Connection::new(":memory:").unwrap();
+        let conn = Arc::new(Mutex::new(conn));
+        let executor = QueryExecutor::new(conn.clone());
+
+        // Create table manually for testing
+        {
+            let c = conn.blocking_lock();
+            c.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)")
+                .unwrap();
+        }
+
+        let lua = Lua::new();
+
+        // Test insert
+        let data = lua.create_table().unwrap();
+        data.set("name", "Alice").unwrap();
+        data.set("age", 30).unwrap();
+
+        let sql = "INSERT INTO users (name, age) VALUES ('Alice', 30)";
+        let result = executor
+            .execute_insert(&lua, sql, "users", LuaValue::Table(data))
+            .unwrap();
+
+        if let LuaValue::Table(t) = result {
+            assert!(t.get::<bool>("success").unwrap());
+        }
+
+        // Test query
+        let rows = executor
+            .execute_query(&lua, "SELECT * FROM users", "all")
+            .unwrap();
+
+        if let LuaValue::Table(t) = rows {
+            assert_eq!(t.len().unwrap(), 1);
+        }
+    }
+}

--- a/rover-db/src/executor.rs
+++ b/rover-db/src/executor.rs
@@ -37,14 +37,12 @@ impl QueryExecutor {
             _ => {
                 return Err(LuaError::RuntimeError(
                     "Insert data must be a table".to_string(),
-                ))
+                ));
             }
         };
 
         // Check if table exists, if not infer schema and create it
-        let conn = self
-            .conn
-            .blocking_lock();
+        let conn = self.conn.blocking_lock();
 
         if !table_name.is_empty() && !conn.table_exists(table_name).unwrap_or(false) {
             // Infer schema from data
@@ -54,7 +52,9 @@ impl QueryExecutor {
                 .map_err(|e| LuaError::RuntimeError(e.to_string()))?;
 
             // Generate and execute CREATE TABLE
-            let create_sql = self.schema_manager.generate_create_table(table_name, &schema);
+            let create_sql = self
+                .schema_manager
+                .generate_create_table(table_name, &schema);
 
             conn.execute(&create_sql)
                 .map_err(|e| LuaError::RuntimeError(format!("Failed to create table: {}", e)))?;

--- a/rover-db/src/file_analyzer.rs
+++ b/rover-db/src/file_analyzer.rs
@@ -1,0 +1,317 @@
+//! File analyzer - analyzes Lua files for DB usage using AST
+//!
+//! Uses tree-sitter to parse Lua code and detect which tables are being used,
+//! so we can prompt the user to create them before execution.
+
+use crate::connection::Connection;
+use std::collections::HashSet;
+use tree_sitter::{Node, Parser};
+
+/// Analyze a Lua file and return the set of tables being used
+pub fn analyze_db_usage(file_content: &str) -> HashSet<String> {
+    let mut tables = HashSet::new();
+
+    // Parse the Lua code
+    let mut parser = Parser::new();
+    let language = tree_sitter_lua::LANGUAGE;
+    parser
+        .set_language(&language.into())
+        .expect("Error loading Lua parser");
+
+    let Some(tree) = parser.parse(file_content, None) else {
+        return tables;
+    };
+
+    // Walk the AST to find db.* patterns
+    walk_tree(tree.root_node(), file_content, &mut tables);
+
+    tables
+}
+
+/// Recursively walk the AST to find db table accesses
+fn walk_tree<'a>(node: Node<'a>, source: &'a str, tables: &mut HashSet<String>) {
+    match node.kind() {
+        "function_call" => {
+            // Handle method calls like db.users:insert(), db.orders:find()
+            if let Some(table_name) = extract_table_from_call(node, source) {
+                tables.insert(table_name);
+            }
+        }
+        "dot_index_expression" => {
+            // Handle field access like db.orders.id, db.users.name
+            if let Some(table_name) = extract_table_from_dot_access(node, source) {
+                tables.insert(table_name);
+            }
+        }
+        _ => {}
+    }
+
+    // Recurse into children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_tree(child, source, tables);
+    }
+}
+
+/// Extract table name from a function call like db.users:insert() or db.users:find():all()
+fn extract_table_from_call(call_node: Node, source: &str) -> Option<String> {
+    let mut cursor = call_node.walk();
+
+    for child in call_node.children(&mut cursor) {
+        match child.kind() {
+            "method_index_expression" => {
+                // This is like: db.users:insert
+                // The object part is in the first child
+                if let Some(object) = child.named_child(0) {
+                    return extract_db_table_name(object, source);
+                }
+            }
+            "dot_index_expression" => {
+                // This could be db.users.sql or similar
+                return extract_db_table_name(child, source);
+            }
+            "identifier" | "function_call" => {
+                // Recursive call like db.users:find():all()
+                // The inner function_call contains the actual db access
+                if child.kind() == "function_call" {
+                    return extract_table_from_call(child, source);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+/// Extract table name from a dot_index_expression like db.users or db.orders.id
+fn extract_table_from_dot_access(node: Node, source: &str) -> Option<String> {
+    extract_db_table_name(node, source)
+}
+
+/// Extract the table name if the expression starts with "db."
+/// Returns the second component of the path (e.g., "users" from "db.users" or "db.users.id")
+fn extract_db_table_name(node: Node, source: &str) -> Option<String> {
+    // Build the full path by walking up/down the dot expression
+    let parts = collect_dot_parts(node, source);
+
+    // Check if this is a db.* pattern (first part must be "db")
+    if parts.len() >= 2 && parts[0] == "db" {
+        // Return the table name (second component)
+        Some(parts[1].clone())
+    } else {
+        None
+    }
+}
+
+/// Collect all parts of a dot expression
+/// For "db.users.id", returns ["db", "users", "id"]
+fn collect_dot_parts(node: Node, source: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    collect_dot_parts_recursive(node, source, &mut parts);
+    parts
+}
+
+fn collect_dot_parts_recursive(node: Node, source: &str, parts: &mut Vec<String>) {
+    match node.kind() {
+        "identifier" => {
+            let text = &source[node.start_byte()..node.end_byte()];
+            parts.push(text.to_string());
+        }
+        "dot_index_expression" => {
+            // First child is the base (could be another dot_index_expression or identifier)
+            // Last identifier child is the field name
+            let mut cursor = node.walk();
+            let children: Vec<_> = node.children(&mut cursor).collect();
+
+            // Process base first (left side)
+            if let Some(base) = children.first() {
+                collect_dot_parts_recursive(*base, source, parts);
+            }
+
+            // Then add the field (last identifier)
+            for child in children.iter().rev() {
+                if child.kind() == "identifier" {
+                    let text = &source[child.start_byte()..child.end_byte()];
+                    parts.push(text.to_string());
+                    break;
+                }
+            }
+        }
+        "method_index_expression" => {
+            // Similar to dot_index_expression but for method calls with ':'
+            // We only care about the object part (before the colon)
+            if let Some(object) = node.named_child(0) {
+                collect_dot_parts_recursive(object, source, parts);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Result of file analysis
+#[derive(Debug, Clone)]
+pub struct AnalysisResult {
+    pub file_path: String,
+    pub tables_used: Vec<String>,
+    pub tables_missing: Vec<String>,
+}
+
+/// Analyze a file and check which tables are missing from the database
+pub fn analyze_file_with_db(
+    file_path: &str,
+    file_content: &str,
+    db_path: &str,
+) -> Result<AnalysisResult, String> {
+    let tables_used = analyze_db_usage(file_content);
+    let tables_missing = check_missing_tables(&tables_used, db_path)?;
+
+    Ok(AnalysisResult {
+        file_path: file_path.to_string(),
+        tables_used: tables_used.into_iter().collect(),
+        tables_missing,
+    })
+}
+
+/// Check which tables from a set don't exist in the database
+fn check_missing_tables(tables: &HashSet<String>, db_path: &str) -> Result<Vec<String>, String> {
+    let connection =
+        Connection::new(db_path).map_err(|e| format!("Failed to open database: {}", e))?;
+
+    let mut missing = Vec::new();
+
+    // Check which tables are missing
+    for table in tables {
+        if !connection
+            .table_exists(table)
+            .map_err(|e| format!("Failed to check table: {}", e))?
+        {
+            missing.push(table.clone());
+        }
+    }
+
+    Ok(missing)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_analyze_db_usage_basic() {
+        let code = r#"
+            local db = rover.db.connect()
+
+            db.users:insert({ name = "Alice" })
+            db.orders:find():all()
+            db.products:update():set({ price = 10 }):exec()
+        "#;
+
+        let tables = analyze_db_usage(code);
+        assert_eq!(tables.len(), 3);
+        assert!(tables.contains("users"));
+        assert!(tables.contains("orders"));
+        assert!(tables.contains("products"));
+    }
+
+    #[test]
+    fn test_analyze_db_usage_with_sql() {
+        let code = r#"
+            local db = rover.db.connect()
+
+            db.users:sql():raw("SELECT * FROM users")
+        "#;
+
+        let tables = analyze_db_usage(code);
+        assert_eq!(tables.len(), 1);
+        assert!(tables.contains("users"));
+    }
+
+    #[test]
+    fn test_analyze_db_usage_with_chained_calls() {
+        let code = r#"
+            local user = db.users:find():by_id(1):first()
+
+            db.users:update()
+                :by_id(user.id)
+                :set({ status = "active" })
+                :exec()
+
+            db.orders:delete():by_status("cancelled"):exec()
+        "#;
+
+        let tables = analyze_db_usage(code);
+        assert_eq!(tables.len(), 2);
+        assert!(tables.contains("users"));
+        assert!(tables.contains("orders"));
+    }
+
+    #[test]
+    fn test_analyze_db_usage_with_field_access() {
+        let code = r#"
+            local order_summary = db.orders:find()
+                :group_by(db.orders.user_id)
+                :agg({
+                    total = rover.db.sum(db.orders.amount),
+                    count = rover.db.count(db.orders.id)
+                })
+                :all()
+        "#;
+
+        let tables = analyze_db_usage(code);
+        assert_eq!(tables.len(), 1);
+        assert!(tables.contains("orders"));
+    }
+
+    #[test]
+    fn test_analyze_db_usage_multiple_tables() {
+        let code = r#"
+            local db = rover.db.connect()
+
+            local user1 = db.users:insert({ name = "Alice" })
+            local order1 = db.orders:insert({ user_id = user1.id, amount = 100 })
+
+            local query = db.users:find()
+                :order_by(db.users.name, "ASC")
+                :limit(10)
+        "#;
+
+        let tables = analyze_db_usage(code);
+        assert_eq!(tables.len(), 2);
+        assert!(tables.contains("users"));
+        assert!(tables.contains("orders"));
+    }
+
+    #[test]
+    fn test_analyze_ignores_non_db_calls() {
+        let code = r#"
+            local config = app.config.get("key")
+            local result = util.parse(data)
+            print("hello")
+        "#;
+
+        let tables = analyze_db_usage(code);
+        assert!(tables.is_empty());
+    }
+
+    #[test]
+    fn test_analyze_db_usage_from_example() {
+        let code = r#"
+local db = rover.db.connect()
+
+local user1 = db.users:insert({ name = "Alice", age = 30 })
+local order1 = db.orders:insert({ user_id = user1.id, amount = 100.50 })
+
+local active = db.users:find():by_status("active"):all()
+local big_spenders = db.orders:find()
+    :group_by(db.orders.user_id)
+    :having_total_bigger_than(100)
+    :all()
+        "#;
+
+        let tables = analyze_db_usage(code);
+        assert_eq!(tables.len(), 2);
+        assert!(tables.contains("users"));
+        assert!(tables.contains("orders"));
+    }
+}

--- a/rover-db/src/guard.lua
+++ b/rover-db/src/guard.lua
@@ -1,0 +1,123 @@
+-- Rover Guard - Zod-inspired validator for Lua
+local Guard = {}
+
+-- Helper to create chainable validator
+local function create_validator(validator_type)
+	return {
+		_type = validator_type,
+		_required = false,
+		_required_msg = nil,
+		_default = nil,
+		_enum = nil,
+		_element = nil,
+		_schema = nil,
+		-- Schema/migration modifiers
+		_primary = false,
+		_auto = false,
+		_unique = false,
+		_nullable = true,
+		_references = nil,
+		_index = false,
+
+		required = function(self, msg)
+			self._required = true
+			self._nullable = false
+			self._required_msg = msg
+			return self
+		end,
+
+		default = function(self, value)
+			self._default = value
+			return self
+		end,
+
+		enum = function(self, values)
+			self._enum = values
+			return self
+		end,
+
+		-- Schema modifiers
+		primary = function(self)
+			self._primary = true
+			self._nullable = false
+			return self
+		end,
+
+		auto = function(self)
+			self._auto = true
+			return self
+		end,
+
+		unique = function(self)
+			self._unique = true
+			return self
+		end,
+
+		nullable = function(self)
+			self._nullable = true
+			self._required = false
+			return self
+		end,
+
+		references = function(self, table_col)
+			self._references = table_col
+			return self
+		end,
+
+		index = function(self)
+			self._index = true
+			return self
+		end,
+	}
+end
+
+function Guard:string()
+	return create_validator "string"
+end
+
+function Guard:number()
+	return create_validator "number"
+end
+
+function Guard:integer()
+	return create_validator "integer"
+end
+
+function Guard:boolean()
+	return create_validator "boolean"
+end
+
+function Guard:array(element_validator)
+	local v = create_validator "array"
+	v._element = element_validator
+	return v
+end
+
+function Guard:object(schema)
+	local v = create_validator "object"
+	v._schema = schema
+	return v
+end
+
+-- Helper function to wrap validation in xpcall without stack traces
+function Guard.validate(fn)
+	local success, result = xpcall(fn, function(err)
+		local err_str = tostring(err)
+		-- Remove "runtime error: " prefix
+		err_str = err_str:gsub("^runtime error: ", "")
+		-- Remove stack traceback
+		local stack_pos = err_str:find "\nstack traceback:"
+		if stack_pos then
+			err_str = err_str:sub(1, stack_pos - 1)
+		end
+		return err_str
+	end)
+
+	if not success then
+		error(result, 0) -- Re-throw with level 0 (no additional stack info)
+	end
+
+	return result
+end
+
+return Guard

--- a/rover-db/src/intent_handler.rs
+++ b/rover-db/src/intent_handler.rs
@@ -93,7 +93,7 @@ pub fn generate_schema_content(table: &InferredTable) -> String {
             ""
         };
         lines.push(format!(
-            "    {} = guard:{}(){},",
+            "    {} = rover.guard:{}(){},",
             field.name, guard_type, modifiers
         ));
     }
@@ -111,7 +111,7 @@ pub fn generate_migration_content(
 
     if is_create {
         lines.push(format!("-- Create {} table", table_name));
-        lines.push("function change()".to_string());
+        lines.push("function migration.change()".to_string());
         lines.push(format!("    migration.{}:create({{", table_name));
 
         let mut sorted_fields: Vec<_> = fields.iter().collect();
@@ -142,7 +142,7 @@ pub fn generate_migration_content(
         lines.push("end".to_string());
     } else {
         lines.push(format!("-- Add fields to {}", table_name));
-        lines.push("function change()".to_string());
+        lines.push("function migration.change()".to_string());
         lines.push(format!("    migration.{}:alter_table()", table_name));
 
         for (i, field) in fields.iter().enumerate() {
@@ -228,7 +228,7 @@ pub fn update_schema_file(
     if let Some(close_idx) = lines.iter().rposition(|l| l.trim() == "}") {
         for field in new_fields {
             let guard_type = field.field_type.to_guard_type();
-            let new_line = format!("    {} = guard:{}(),", field.name, guard_type);
+            let new_line = format!("    {} = rover.guard:{}(),", field.name, guard_type);
             lines.insert(close_idx, new_line);
         }
     }

--- a/rover-db/src/intent_handler.rs
+++ b/rover-db/src/intent_handler.rs
@@ -1,0 +1,231 @@
+use crate::schema_analyzer::TableDefinition;
+use rover_parser::db_intent::{DbIntent, FieldType as InferredType, InferredField, InferredTable};
+use std::collections::HashMap;
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::Path;
+
+#[derive(Debug)]
+pub struct TableDiff {
+    pub table_name: String,
+    pub status: TableStatus,
+    pub new_fields: Vec<InferredField>,
+}
+
+#[derive(Debug)]
+pub enum TableStatus {
+    New,
+    Exists,
+    NeedsUpdate,
+}
+
+pub struct IntentComparison {
+    pub diffs: Vec<TableDiff>,
+}
+
+pub fn compare_intent_with_schemas(
+    intent: &DbIntent,
+    schemas: &HashMap<String, TableDefinition>,
+) -> IntentComparison {
+    let mut diffs = Vec::new();
+
+    for (table_name, inferred_table) in &intent.tables {
+        if let Some(existing) = schemas.get(table_name) {
+            let new_fields = find_new_fields(inferred_table, existing);
+            if new_fields.is_empty() {
+                diffs.push(TableDiff {
+                    table_name: table_name.clone(),
+                    status: TableStatus::Exists,
+                    new_fields: vec![],
+                });
+            } else {
+                diffs.push(TableDiff {
+                    table_name: table_name.clone(),
+                    status: TableStatus::NeedsUpdate,
+                    new_fields,
+                });
+            }
+        } else {
+            let new_fields: Vec<_> = inferred_table.fields.values().cloned().collect();
+            diffs.push(TableDiff {
+                table_name: table_name.clone(),
+                status: TableStatus::New,
+                new_fields,
+            });
+        }
+    }
+
+    IntentComparison { diffs }
+}
+
+fn find_new_fields(inferred: &InferredTable, existing: &TableDefinition) -> Vec<InferredField> {
+    let existing_names: std::collections::HashSet<_> =
+        existing.fields.iter().map(|f| f.name.as_str()).collect();
+
+    inferred
+        .fields
+        .values()
+        .filter(|f| !existing_names.contains(f.name.as_str()))
+        .cloned()
+        .collect()
+}
+
+pub fn generate_schema_content(table: &InferredTable) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!("rover.db.schema.{} {{", table.name));
+
+    let mut fields: Vec<_> = table.fields.values().collect();
+    fields.sort_by(|a, b| {
+        if a.name == "id" {
+            std::cmp::Ordering::Less
+        } else if b.name == "id" {
+            std::cmp::Ordering::Greater
+        } else {
+            a.name.cmp(&b.name)
+        }
+    });
+
+    for field in fields {
+        let guard_type = field.field_type.to_guard_type();
+        let modifiers = if field.name == "id" {
+            ":primary():auto()"
+        } else {
+            ""
+        };
+        lines.push(format!("    {} = guard:{}(){},", field.name, guard_type, modifiers));
+    }
+
+    lines.push("}".to_string());
+    lines.join("\n")
+}
+
+pub fn generate_migration_content(table_name: &str, fields: &[InferredField], is_create: bool) -> String {
+    let mut lines = Vec::new();
+
+    if is_create {
+        lines.push(format!("-- Create {} table", table_name));
+        lines.push("return {".to_string());
+        lines.push("    up = function(db)".to_string());
+        lines.push(format!("        db:execute([["));
+        lines.push(format!("            CREATE TABLE {} (", table_name));
+
+        let mut field_lines = Vec::new();
+        let mut sorted_fields: Vec<_> = fields.iter().collect();
+        sorted_fields.sort_by(|a, b| {
+            if a.name == "id" {
+                std::cmp::Ordering::Less
+            } else if b.name == "id" {
+                std::cmp::Ordering::Greater
+            } else {
+                a.name.cmp(&b.name)
+            }
+        });
+
+        for field in sorted_fields {
+            let sql_type = inferred_to_sql_type(&field.field_type);
+            let constraints = if field.name == "id" {
+                " PRIMARY KEY AUTOINCREMENT"
+            } else {
+                ""
+            };
+            field_lines.push(format!("                {} {}{}", field.name, sql_type, constraints));
+        }
+
+        lines.push(field_lines.join(",\n"));
+        lines.push("            )".to_string());
+        lines.push("        ]])".to_string());
+        lines.push("    end,".to_string());
+        lines.push("".to_string());
+        lines.push("    down = function(db)".to_string());
+        lines.push(format!("        db:execute(\"DROP TABLE IF EXISTS {}\")", table_name));
+        lines.push("    end".to_string());
+        lines.push("}".to_string());
+    } else {
+        lines.push(format!("-- Add fields to {}", table_name));
+        lines.push("return {".to_string());
+        lines.push("    up = function(db)".to_string());
+        for field in fields {
+            let sql_type = inferred_to_sql_type(&field.field_type);
+            lines.push(format!(
+                "        db:execute(\"ALTER TABLE {} ADD COLUMN {} {}\")",
+                table_name, field.name, sql_type
+            ));
+        }
+        lines.push("    end,".to_string());
+        lines.push("".to_string());
+        lines.push("    down = function(db)".to_string());
+        lines.push("        -- SQLite doesn't support DROP COLUMN easily".to_string());
+        lines.push("    end".to_string());
+        lines.push("}".to_string());
+    }
+
+    lines.join("\n")
+}
+
+fn inferred_to_sql_type(t: &InferredType) -> &'static str {
+    match t {
+        InferredType::Integer => "INTEGER",
+        InferredType::Number => "REAL",
+        InferredType::String => "TEXT",
+        InferredType::Boolean => "INTEGER",
+        InferredType::Unknown => "TEXT",
+    }
+}
+
+pub fn write_schema_file(schemas_dir: &Path, table_name: &str, content: &str) -> io::Result<()> {
+    fs::create_dir_all(schemas_dir)?;
+    let path = schemas_dir.join(format!("{}.lua", table_name));
+    fs::write(path, content)
+}
+
+pub fn write_migration_file(migrations_dir: &Path, name: &str, content: &str) -> io::Result<String> {
+    fs::create_dir_all(migrations_dir)?;
+
+    let existing: Vec<_> = fs::read_dir(migrations_dir)?
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.file_name().to_str().map(|s| s.to_string()))
+        .collect();
+
+    let next_num = existing
+        .iter()
+        .filter_map(|n| n.split('_').next()?.parse::<u32>().ok())
+        .max()
+        .unwrap_or(0)
+        + 1;
+
+    let filename = format!("{:03}_{}.lua", next_num, name);
+    let path = migrations_dir.join(&filename);
+    fs::write(&path, content)?;
+    Ok(filename)
+}
+
+pub fn prompt_yes_no(message: &str) -> io::Result<bool> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    print!("{} [y/n] ", message);
+    stdout.flush()?;
+
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line)?;
+
+    let answer = line.trim().to_lowercase();
+    Ok(answer == "y" || answer == "yes")
+}
+
+pub fn update_schema_file(schemas_dir: &Path, table_name: &str, new_fields: &[InferredField]) -> io::Result<()> {
+    let path = schemas_dir.join(format!("{}.lua", table_name));
+    let content = fs::read_to_string(&path)?;
+
+    let mut lines: Vec<String> = content.lines().map(|s| s.to_string()).collect();
+
+    if let Some(close_idx) = lines.iter().rposition(|l| l.trim() == "}") {
+        for field in new_fields {
+            let guard_type = field.field_type.to_guard_type();
+            let new_line = format!("    {} = guard:{}(),", field.name, guard_type);
+            lines.insert(close_idx, new_line);
+        }
+    }
+
+    fs::write(path, lines.join("\n"))
+}

--- a/rover-db/src/lib.rs
+++ b/rover-db/src/lib.rs
@@ -46,6 +46,10 @@ pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
         .set_name("migration_dsl.lua")
         .eval()?;
 
+    // Inject schema_dsl into db_lua for schema-aware query methods
+    let set_schema_dsl: LuaFunction = db_lua.get("_set_schema_dsl")?;
+    set_schema_dsl.call::<()>(schema_dsl.clone())?;
+
     let db = lua.create_table()?;
     db.set("schema", schema_dsl)?;
     db.set("migration", migration_dsl)?;

--- a/rover-db/src/lib.rs
+++ b/rover-db/src/lib.rs
@@ -1,0 +1,242 @@
+//! Rover DB - Intent-Based Query Builder & ORM DSL
+//!
+//! This module provides the Rust-side implementation for rover-db,
+//! handling actual SQLite/libsql execution with coroutine support.
+
+use mlua::prelude::*;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+mod connection;
+mod executor;
+mod schema;
+
+pub use connection::Connection;
+pub use executor::QueryExecutor;
+pub use schema::SchemaManager;
+
+/// Thread-local connection pool for database connections
+thread_local! {
+    static CONNECTION_POOL: RefCell<HashMap<String, Arc<Mutex<Connection>>>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Check if we should yield for I/O (running in a coroutine)
+fn should_yield_for_io(lua: &Lua) -> LuaResult<bool> {
+    let globals = lua.globals();
+    if let Ok(coroutine) = globals.get::<LuaTable>("coroutine") {
+        if let Ok(running) = coroutine.get::<LuaFunction>("running") {
+            if let Ok((thread, is_main)) = running.call::<(LuaValue, bool)>(()) {
+                return Ok(!is_main && matches!(thread, LuaValue::Thread(_)));
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// Yield to the event loop (simulates async behavior)
+fn yield_to_event_loop(lua: &Lua) -> LuaResult<()> {
+    let globals = lua.globals();
+    if let Ok(coroutine) = globals.get::<LuaTable>("coroutine") {
+        if let Ok(yield_fn) = coroutine.get::<LuaFunction>("yield") {
+            let _ = yield_fn.call::<()>(());
+        }
+    }
+    Ok(())
+}
+
+/// Create the rover.db module
+pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
+    // Load the Lua DSL module
+    let db_lua: LuaTable = lua
+        .load(include_str!("db.lua"))
+        .set_name("db.lua")
+        .eval()?;
+
+    // Create the main db table that will be returned
+    let db = lua.create_table()?;
+
+    // Copy aggregate functions from DSL
+    for func_name in &["sum", "count", "avg", "min", "max"] {
+        if let Ok(func) = db_lua.get::<LuaFunction>(*func_name) {
+            db.set(*func_name, func)?;
+        }
+    }
+
+    // Store reference to the DSL module for creating instances
+    let db_lua_ref = lua.create_registry_value(db_lua)?;
+
+    // Create the connect function
+    let connect_fn = lua.create_function(move |lua, config: Option<LuaTable>| {
+        let db_lua: LuaTable = lua.registry_value(&db_lua_ref)?;
+        let connect_fn: LuaFunction = db_lua.get("connect")?;
+
+        // Call Lua's connect to get the instance
+        let instance: LuaTable = connect_fn.call(config.clone())?;
+
+        // Extract connection path from config
+        let db_path = if let Some(ref cfg) = config {
+            cfg.get::<String>("path").unwrap_or_else(|_| ":memory:".to_string())
+        } else {
+            ":memory:".to_string()
+        };
+
+        // Create executor function that will handle all DB operations
+        let executor = create_executor(lua, db_path)?;
+        instance.set("_executor", executor)?;
+
+        Ok(instance)
+    })?;
+
+    db.set("connect", connect_fn)?;
+
+    Ok(db)
+}
+
+/// Create the executor function that bridges Lua queries to actual DB operations
+fn create_executor(lua: &Lua, db_path: String) -> LuaResult<LuaFunction> {
+    // Initialize connection
+    let conn = Connection::new(&db_path).map_err(|e| LuaError::external(e))?;
+    let conn = Arc::new(Mutex::new(conn));
+
+    // Store in thread-local pool
+    let path_clone = db_path.clone();
+    CONNECTION_POOL.with(|pool| {
+        pool.borrow_mut().insert(path_clone, conn.clone());
+    });
+
+    let executor = QueryExecutor::new(conn);
+    let executor = Arc::new(executor);
+
+    lua.create_function(move |lua, args: LuaMultiValue| {
+        let args_vec: Vec<LuaValue> = args.into_iter().collect();
+
+        if args_vec.is_empty() {
+            return Err(LuaError::RuntimeError(
+                "Executor requires at least one argument".to_string(),
+            ));
+        }
+
+        let operation = match &args_vec[0] {
+            LuaValue::String(s) => s.to_str()?.to_string(),
+            _ => {
+                return Err(LuaError::RuntimeError(
+                    "First argument must be operation type".to_string(),
+                ))
+            }
+        };
+
+        let sql = if args_vec.len() > 1 {
+            match &args_vec[1] {
+                LuaValue::String(s) => s.to_str()?.to_string(),
+                _ => String::new(),
+            }
+        } else {
+            String::new()
+        };
+
+        // Check if we should yield for async behavior
+        let should_yield = should_yield_for_io(lua)?;
+
+        // Execute the operation
+        let result = match operation.as_str() {
+            "insert" => {
+                let table_name = if args_vec.len() > 3 {
+                    match &args_vec[3] {
+                        LuaValue::String(s) => s.to_str()?.to_string(),
+                        _ => String::new(),
+                    }
+                } else {
+                    String::new()
+                };
+
+                let data = if args_vec.len() > 2 {
+                    args_vec[2].clone()
+                } else {
+                    LuaValue::Nil
+                };
+
+                executor.execute_insert(lua, &sql, &table_name, data)
+            }
+            "query" => {
+                let mode = if args_vec.len() > 3 {
+                    match &args_vec[3] {
+                        LuaValue::String(s) => s.to_str()?.to_string(),
+                        _ => "all".to_string(),
+                    }
+                } else {
+                    "all".to_string()
+                };
+
+                executor.execute_query(lua, &sql, &mode)
+            }
+            "update" => executor.execute_update(&sql),
+            "delete" => executor.execute_delete(&sql),
+            "raw" => {
+                let params = if args_vec.len() > 2 {
+                    match &args_vec[2] {
+                        LuaValue::Table(t) => Some(t.clone()),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                executor.execute_raw(lua, &sql, params)
+            }
+            _ => Err(LuaError::RuntimeError(format!(
+                "Unknown operation: {}",
+                operation
+            ))),
+        };
+
+        // Yield if running in coroutine
+        if should_yield {
+            yield_to_event_loop(lua)?;
+        }
+
+        result
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_db_module() {
+        let lua = Lua::new();
+        let db = create_db_module(&lua).unwrap();
+
+        // Check that connect function exists
+        assert!(db.get::<LuaFunction>("connect").is_ok());
+
+        // Check that aggregate functions exist
+        assert!(db.get::<LuaFunction>("sum").is_ok());
+        assert!(db.get::<LuaFunction>("count").is_ok());
+        assert!(db.get::<LuaFunction>("avg").is_ok());
+        assert!(db.get::<LuaFunction>("min").is_ok());
+        assert!(db.get::<LuaFunction>("max").is_ok());
+    }
+
+    #[test]
+    fn test_connect_memory() {
+        let lua = Lua::new();
+        let db = create_db_module(&lua).unwrap();
+        lua.globals().set("db_module", db).unwrap();
+
+        let result: LuaTable = lua
+            .load(
+                r#"
+            local db = db_module.connect()
+            return db
+        "#,
+            )
+            .eval()
+            .unwrap();
+
+        // Should have _executor
+        assert!(result.get::<LuaFunction>("_executor").is_ok());
+    }
+}

--- a/rover-db/src/lib.rs
+++ b/rover-db/src/lib.rs
@@ -4,52 +4,21 @@
 //! handling actual SQLite/libsql execution with coroutine support.
 
 use mlua::prelude::*;
-use std::cell::RefCell;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 mod connection;
 mod executor;
+mod migration;
 mod schema;
 
 pub use connection::Connection;
 pub use executor::QueryExecutor;
+pub use migration::{MigrationExecutor, rollback_migrations, run_pending_migrations};
 pub use schema::SchemaManager;
 
-/// Thread-local connection pool for database connections
-thread_local! {
-    static CONNECTION_POOL: RefCell<HashMap<String, Arc<Mutex<Connection>>>> =
-        RefCell::new(HashMap::new());
-}
-
-/// Check if we should yield for I/O (running in a coroutine)
-fn should_yield_for_io(lua: &Lua) -> LuaResult<bool> {
-    let globals = lua.globals();
-    if let Ok(coroutine) = globals.get::<LuaTable>("coroutine") {
-        if let Ok(running) = coroutine.get::<LuaFunction>("running") {
-            if let Ok((thread, is_main)) = running.call::<(LuaValue, bool)>(()) {
-                return Ok(!is_main && matches!(thread, LuaValue::Thread(_)));
-            }
-        }
-    }
-    Ok(false)
-}
-
-/// Yield to the event loop (simulates async behavior)
-fn yield_to_event_loop(lua: &Lua) -> LuaResult<()> {
-    let globals = lua.globals();
-    if let Ok(coroutine) = globals.get::<LuaTable>("coroutine") {
-        if let Ok(yield_fn) = coroutine.get::<LuaFunction>("yield") {
-            let _ = yield_fn.call::<()>(());
-        }
-    }
-    Ok(())
-}
-
-/// Create the rover.db module
 pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
-    // Load the Lua DSL modules
+    // Load Lua DSL modules
     let db_lua: LuaTable = lua.load(include_str!("db.lua")).set_name("db.lua").eval()?;
     let schema_dsl: LuaTable = lua
         .load(include_str!("schema_dsl.lua"))
@@ -64,7 +33,7 @@ pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
         .set_name("analyzer.lua")
         .eval()?;
 
-    // Create the main db table that will be returned
+    // Create main db table that will be returned
     let db = lua.create_table()?;
 
     // Copy aggregate functions from DSL
@@ -77,8 +46,31 @@ pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
     // Add schema DSL
     db.set("schema", schema_dsl)?;
 
-    // Add migration DSL
+    // Add migration DSL and expose executor
     db.set("migration", migration_dsl.clone())?;
+
+    // Capture executor for use in closures
+    let executor_for_closure = executor.clone();
+
+    // Add migration functions to db module
+    db.set(
+        "run_pending_migrations",
+        lua.create_function(move |lua, _: ()| {
+            let migrations_dir = std::env::current_dir().join("db/migrations");
+            run_pending_migrations(lua, executor_for_closure.clone(), &migrations_dir)
+                .map_err(|e| LuaError::external(e))
+        }),
+    )?;
+
+    db.set(
+        "rollback_migrations",
+        lua.create_function(move |lua, steps: Option<i64>| {
+            let steps = steps.unwrap_or(1) as usize;
+            let migrations_dir = std::env::current_dir().join("db/migrations");
+            rollback_migrations(lua, executor_for_closure.clone(), &migrations_dir, steps)
+                .map_err(|e| LuaError::external(e))
+        }),
+    )?;
 
     // Store reference to the DSL modules for creating instances
     let db_lua_ref = lua.create_registry_value(db_lua)?;
@@ -109,150 +101,4 @@ pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
     db.set("connect", connect_fn)?;
 
     Ok(db)
-}
-
-/// Create the executor function that bridges Lua queries to actual DB operations
-fn create_executor(lua: &Lua, db_path: String) -> LuaResult<LuaFunction> {
-    // Initialize connection
-    let conn = Connection::new(&db_path).map_err(|e| LuaError::external(e))?;
-    let conn = Arc::new(Mutex::new(conn));
-
-    // Store in thread-local pool
-    let path_clone = db_path.clone();
-    CONNECTION_POOL.with(|pool| {
-        pool.borrow_mut().insert(path_clone, conn.clone());
-    });
-
-    let executor = QueryExecutor::new(conn);
-    let executor = Arc::new(executor);
-
-    lua.create_function(move |lua, args: LuaMultiValue| {
-        let args_vec: Vec<LuaValue> = args.into_iter().collect();
-
-        if args_vec.is_empty() {
-            return Err(LuaError::RuntimeError(
-                "Executor requires at least one argument".to_string(),
-            ));
-        }
-
-        let operation = match &args_vec[0] {
-            LuaValue::String(s) => s.to_str()?.to_string(),
-            _ => {
-                return Err(LuaError::RuntimeError(
-                    "First argument must be operation type".to_string(),
-                ));
-            }
-        };
-
-        let sql = if args_vec.len() > 1 {
-            match &args_vec[1] {
-                LuaValue::String(s) => s.to_str()?.to_string(),
-                _ => String::new(),
-            }
-        } else {
-            String::new()
-        };
-
-        // Check if we should yield for async behavior
-        let should_yield = should_yield_for_io(lua)?;
-
-        // Execute the operation
-        let result = match operation.as_str() {
-            "insert" => {
-                let table_name = if args_vec.len() > 3 {
-                    match &args_vec[3] {
-                        LuaValue::String(s) => s.to_str()?.to_string(),
-                        _ => String::new(),
-                    }
-                } else {
-                    String::new()
-                };
-
-                let data = if args_vec.len() > 2 {
-                    args_vec[2].clone()
-                } else {
-                    LuaValue::Nil
-                };
-
-                executor.execute_insert(lua, &sql, &table_name, data)
-            }
-            "query" => {
-                let mode = if args_vec.len() > 3 {
-                    match &args_vec[3] {
-                        LuaValue::String(s) => s.to_str()?.to_string(),
-                        _ => "all".to_string(),
-                    }
-                } else {
-                    "all".to_string()
-                };
-
-                executor.execute_query(lua, &sql, &mode)
-            }
-            "update" => executor.execute_update(&sql),
-            "delete" => executor.execute_delete(&sql),
-            "raw" => {
-                let params = if args_vec.len() > 2 {
-                    match &args_vec[2] {
-                        LuaValue::Table(t) => Some(t.clone()),
-                        _ => None,
-                    }
-                } else {
-                    None
-                };
-                executor.execute_raw(lua, &sql, params)
-            }
-            _ => Err(LuaError::RuntimeError(format!(
-                "Unknown operation: {}",
-                operation
-            ))),
-        };
-
-        // Yield if running in coroutine
-        if should_yield {
-            yield_to_event_loop(lua)?;
-        }
-
-        result
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_create_db_module() {
-        let lua = Lua::new();
-        let db = create_db_module(&lua).unwrap();
-
-        // Check that connect function exists
-        assert!(db.get::<LuaFunction>("connect").is_ok());
-
-        // Check that aggregate functions exist
-        assert!(db.get::<LuaFunction>("sum").is_ok());
-        assert!(db.get::<LuaFunction>("count").is_ok());
-        assert!(db.get::<LuaFunction>("avg").is_ok());
-        assert!(db.get::<LuaFunction>("min").is_ok());
-        assert!(db.get::<LuaFunction>("max").is_ok());
-    }
-
-    #[test]
-    fn test_connect_memory() {
-        let lua = Lua::new();
-        let db = create_db_module(&lua).unwrap();
-        lua.globals().set("db_module", db).unwrap();
-
-        let result: LuaTable = lua
-            .load(
-                r#"
-            local db = db_module.connect()
-            return db
-        "#,
-            )
-            .eval()
-            .unwrap();
-
-        // Should have _executor
-        assert!(result.get::<LuaFunction>("_executor").is_ok());
-    }
 }

--- a/rover-db/src/lib.rs
+++ b/rover-db/src/lib.rs
@@ -4,19 +4,36 @@
 //! handling actual SQLite/libsql execution with coroutine support.
 
 use mlua::prelude::*;
+use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 mod connection;
 mod executor;
+mod file_analyzer;
+pub mod intent_handler;
 mod migration;
 mod schema;
+mod schema_analyzer;
 
 pub use connection::Connection;
 pub use executor::QueryExecutor;
-pub use migration::{MigrationExecutor, rollback_migrations, run_pending_migrations};
+pub use file_analyzer::{AnalysisResult, analyze_db_usage, analyze_file_with_db};
+pub use intent_handler::{
+    IntentComparison, TableDiff, TableStatus, compare_intent_with_schemas,
+    generate_migration_content, generate_schema_content, prompt_yes_no,
+    update_schema_file, write_migration_file, write_schema_file,
+};
+pub use migration::{
+    MigrationExecutor, MigrationStatus, rollback_migrations, run_pending_migrations,
+};
 pub use schema::SchemaManager;
+pub use schema_analyzer::{
+    FieldDefinition, FieldType, ForeignKey, TableDefinition, generate_create_table, load_schemas,
+    load_schemas_from_dir,
+};
 
+/// Create the rover.db module for Lua
 pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
     // Load Lua DSL modules
     let db_lua: LuaTable = lua.load(include_str!("db.lua")).set_name("db.lua").eval()?;
@@ -27,10 +44,6 @@ pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
     let migration_dsl: LuaTable = lua
         .load(include_str!("migration_dsl.lua"))
         .set_name("migration_dsl.lua")
-        .eval()?;
-    let analyzer: LuaTable = lua
-        .load(include_str!("analyzer.lua"))
-        .set_name("analyzer.lua")
         .eval()?;
 
     // Create main db table that will be returned
@@ -46,31 +59,8 @@ pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
     // Add schema DSL
     db.set("schema", schema_dsl)?;
 
-    // Add migration DSL and expose executor
-    db.set("migration", migration_dsl.clone())?;
-
-    // Capture executor for use in closures
-    let executor_for_closure = executor.clone();
-
-    // Add migration functions to db module
-    db.set(
-        "run_pending_migrations",
-        lua.create_function(move |lua, _: ()| {
-            let migrations_dir = std::env::current_dir().join("db/migrations");
-            run_pending_migrations(lua, executor_for_closure.clone(), &migrations_dir)
-                .map_err(|e| LuaError::external(e))
-        }),
-    )?;
-
-    db.set(
-        "rollback_migrations",
-        lua.create_function(move |lua, steps: Option<i64>| {
-            let steps = steps.unwrap_or(1) as usize;
-            let migrations_dir = std::env::current_dir().join("db/migrations");
-            rollback_migrations(lua, executor_for_closure.clone(), &migrations_dir, steps)
-                .map_err(|e| LuaError::external(e))
-        }),
-    )?;
+    // Add migration DSL
+    db.set("migration", migration_dsl)?;
 
     // Store reference to the DSL modules for creating instances
     let db_lua_ref = lua.create_registry_value(db_lua)?;
@@ -101,4 +91,147 @@ pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
     db.set("connect", connect_fn)?;
 
     Ok(db)
+}
+
+/// Create the executor function for database operations
+fn create_executor(lua: &Lua, db_path: String) -> LuaResult<LuaFunction> {
+    // Create the actual connection
+    let conn = Connection::new(&db_path)
+        .map_err(|e| LuaError::RuntimeError(format!("Failed to connect to database: {}", e)))?;
+
+    let conn = Arc::new(Mutex::new(conn));
+    let executor = QueryExecutor::new(conn.clone());
+
+    // Create a Lua userdata wrapper for the executor
+    let executor = Arc::new(executor);
+
+    lua.create_function(move |lua, args: LuaMultiValue| {
+        // Extract operation type and SQL from args
+        let args_vec: Vec<LuaValue> = args.into_iter().collect();
+
+        if args_vec.is_empty() {
+            return Err(LuaError::RuntimeError(
+                "Executor requires at least one argument".to_string(),
+            ));
+        }
+
+        let operation = match &args_vec[0] {
+            LuaValue::String(s) => s.to_str()?.to_string(),
+            _ => {
+                return Err(LuaError::RuntimeError(
+                    "First argument must be operation type string".to_string(),
+                ));
+            }
+        };
+
+        let sql = if args_vec.len() > 1 {
+            match &args_vec[1] {
+                LuaValue::String(s) => s.to_str()?.to_string(),
+                _ => String::new(),
+            }
+        } else {
+            String::new()
+        };
+
+        match operation.as_str() {
+            "query" | "select" => {
+                let mode = if args_vec.len() > 2 {
+                    match &args_vec[2] {
+                        LuaValue::String(s) => s.to_str()?.to_string(),
+                        _ => "all".to_string(),
+                    }
+                } else {
+                    "all".to_string()
+                };
+                executor.execute_query(lua, &sql, &mode)
+            }
+            "insert" => {
+                let table_name = if args_vec.len() > 2 {
+                    match &args_vec[2] {
+                        LuaValue::String(s) => s.to_str()?.to_string(),
+                        _ => String::new(),
+                    }
+                } else {
+                    String::new()
+                };
+
+                let data = if args_vec.len() > 3 {
+                    args_vec[3].clone()
+                } else {
+                    LuaValue::Nil
+                };
+
+                executor.execute_insert(lua, &sql, &table_name, data)
+            }
+            "update" => executor.execute_update(&sql),
+            "delete" => executor.execute_delete(&sql),
+            "raw" => {
+                let params = if args_vec.len() > 2 {
+                    match &args_vec[2] {
+                        LuaValue::Table(t) => Some(t.clone()),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                executor.execute_raw(lua, &sql, params)
+            }
+            _ => Err(LuaError::RuntimeError(format!(
+                "Unknown operation: {}",
+                operation
+            ))),
+        }
+    })
+}
+
+/// Run migrations from a directory
+pub fn run_migrations(db_path: &str, migrations_dir: &Path) -> Result<usize, String> {
+    let conn = Connection::new(db_path).map_err(|e| format!("Failed to connect: {}", e))?;
+
+    let conn = Arc::new(Mutex::new(conn));
+    let executor = MigrationExecutor::new(conn);
+
+    run_pending_migrations(&executor, migrations_dir).map_err(|e| e.to_string())
+}
+
+/// Rollback migrations
+pub fn rollback(db_path: &str, migrations_dir: &Path, steps: usize) -> Result<usize, String> {
+    let conn = Connection::new(db_path).map_err(|e| format!("Failed to connect: {}", e))?;
+
+    let conn = Arc::new(Mutex::new(conn));
+    let executor = MigrationExecutor::new(conn);
+
+    rollback_migrations(&executor, migrations_dir, steps).map_err(|e| e.to_string())
+}
+
+/// Get migration status
+pub fn migration_status(db_path: &str, migrations_dir: &Path) -> Result<MigrationStatus, String> {
+    let conn = Connection::new(db_path).map_err(|e| format!("Failed to connect: {}", e))?;
+
+    let conn = Arc::new(Mutex::new(conn));
+    let executor = MigrationExecutor::new(conn);
+
+    executor
+        .get_status(migrations_dir)
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_db_module() {
+        let lua = Lua::new();
+        let db = create_db_module(&lua).unwrap();
+
+        // Check that connect function exists
+        assert!(db.get::<LuaFunction>("connect").is_ok());
+
+        // Check that schema DSL exists
+        assert!(db.get::<LuaTable>("schema").is_ok());
+
+        // Check that migration DSL exists
+        assert!(db.get::<LuaTable>("migration").is_ok());
+    }
 }

--- a/rover-db/src/lib.rs.bak
+++ b/rover-db/src/lib.rs.bak
@@ -1,0 +1,288 @@
+//! Rover DB - Intent-Based Query Builder & ORM DSL
+//!
+//! This module provides the Rust-side implementation for rover-db,
+//! handling actual SQLite/libsql execution with coroutine support.
+
+use mlua::prelude::*;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+mod connection;
+mod executor;
+mod migration;
+mod schema;
+
+pub use connection::Connection;
+pub use executor::QueryExecutor;
+pub use migration::{MigrationExecutor, rollback_migrations, run_pending_migrations};
+pub use schema::SchemaManager;
+
+/// Thread-local connection pool for database connections
+thread_local! {
+    static CONNECTION_POOL: RefCell<HashMap<String, Arc<Mutex<Connection>>>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Check if we should yield for I/O (running in a coroutine)
+fn should_yield_for_io(lua: &Lua) -> LuaResult<bool> {
+    let globals = lua.globals();
+    if let Ok(coroutine) = globals.get::<LuaTable>("coroutine") {
+        if let Ok(running) = coroutine.get::<LuaFunction>("running") {
+            if let Ok((thread, is_main)) = running.call::<(LuaValue, bool)>(()) {
+                return Ok(!is_main && matches!(thread, LuaValue::Thread(_)));
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// Yield to the event loop (simulates async behavior)
+fn yield_to_event_loop(lua: &Lua) -> LuaResult<()> {
+    let globals = lua.globals();
+    if let Ok(coroutine) = globals.get::<LuaTable>("coroutine") {
+        if let Ok(yield_fn) = coroutine.get::<LuaFunction>("yield") {
+            let _ = yield_fn.call::<()>(());
+        }
+    }
+    Ok(())
+}
+
+/// Create the rover.db module
+pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
+    // Load the Lua DSL modules
+    let db_lua: LuaTable = lua.load(include_str!("db.lua")).set_name("db.lua").eval()?;
+    let schema_dsl: LuaTable = lua
+        .load(include_str!("schema_dsl.lua"))
+        .set_name("schema_dsl.lua")
+        .eval()?;
+    let migration_dsl: LuaTable = lua
+        .load(include_str!("migration_dsl.lua"))
+        .set_name("migration_dsl.lua")
+        .eval()?;
+    let analyzer: LuaTable = lua
+        .load(include_str!("analyzer.lua"))
+        .set_name("analyzer.lua")
+        .eval()?;
+
+    // Create the main db table that will be returned
+    let db = lua.create_table()?;
+
+    // Copy aggregate functions from DSL
+    for func_name in &["sum", "count", "avg", "min", "max"] {
+        if let Ok(func) = db_lua.get::<LuaFunction>(*func_name) {
+            db.set(*func_name, func)?;
+        }
+    }
+
+    // Add schema DSL
+    db.set("schema", schema_dsl)?;
+
+    // Add migration DSL and expose executor
+    db.set("migration", migration_dsl.clone())?;
+
+    // Capture executor for use in closures
+    let executor_for_closure = executor.clone();
+
+    // Add migration functions to db module
+    db.set("run_pending_migrations", lua.create_function(move |lua, _: ()| {
+        let migrations_dir = std::env::current_dir().join("db/migrations");
+        run_pending_migrations(lua, executor_for_closure.clone(), &migrations_dir)
+            .map_err(|e| LuaError::external(e))
+    });
+
+    db.set("rollback_migrations", lua.create_function(move |lua, steps: Option<i64>| {
+        let steps = steps.unwrap_or(1) as usize;
+        let migrations_dir = std::env::current_dir().join("db/migrations");
+        rollback_migrations(lua, executor_for_closure.clone(), &migrations_dir, steps)
+            .map_err(|e| LuaError::external(e))
+    });
+
+    db.set("rollback_migrations", lua.create_function(move |lua, steps: Option<i64>| {
+        let steps = steps.unwrap_or(1) as usize;
+        let migrations_dir = std::env::current_dir().join("db/migrations");
+        rollback_migrations(lua, &executor, &migrations_dir, steps)
+            .map_err(|e| LuaError::external(e))
+    })?)?;
+
+    db.set("rollback_migrations", lua.create_function(move |_, steps: Option<i64>| {
+        let steps = steps.unwrap_or(1) as usize;
+        let migrations_dir = std::env::current_dir().join("db/migrations");
+        rollback_migrations(&lua, executor_clone.clone(), &migrations_dir, steps)
+            .map_err(|e| LuaError::external(e))
+    })?;
+
+    // Create the connect function
+    let connect_fn = lua.create_function(move |lua, config: Option<LuaTable>| {
+        let db_lua: LuaTable = lua.registry_value(&db_lua_ref)?;
+        let connect_fn: LuaFunction = db_lua.get("connect")?;
+
+        // Call Lua's connect to get the instance
+        let instance: LuaTable = connect_fn.call(config.clone())?;
+
+        // Extract connection path from config
+        let db_path = if let Some(ref cfg) = config {
+            cfg.get::<String>("path")
+                .unwrap_or_else(|_| "rover.sqlite".to_string())
+        } else {
+            "rover.sqlite".to_string()
+        };
+
+        // Create executor function that will handle all DB operations
+        let executor = create_executor(lua, db_path)?;
+        instance.set("_executor", executor)?;
+
+        Ok(instance)
+    })?;
+
+    db.set("connect", connect_fn)?;
+
+    Ok(db)
+}
+
+/// Create the executor function that bridges Lua queries to actual DB operations
+fn create_executor(lua: &Lua, db_path: String) -> LuaResult<LuaFunction> {
+    // Initialize connection
+    let conn = Connection::new(&db_path).map_err(|e| LuaError::external(e))?;
+    let conn = Arc::new(Mutex::new(conn));
+
+    // Store in thread-local pool
+    let path_clone = db_path.clone();
+    CONNECTION_POOL.with(|pool| {
+        pool.borrow_mut().insert(path_clone, conn.clone());
+    });
+
+    let executor = QueryExecutor::new(conn);
+    let executor = Arc::new(executor);
+
+    lua.create_function(move |lua, args: LuaMultiValue| {
+        let args_vec: Vec<LuaValue> = args.into_iter().collect();
+
+        if args_vec.is_empty() {
+            return Err(LuaError::RuntimeError(
+                "Executor requires at least one argument".to_string(),
+            ));
+        }
+
+        let operation = match &args_vec[0] {
+            LuaValue::String(s) => s.to_str()?.to_string(),
+            _ => {
+                return Err(LuaError::RuntimeError(
+                    "First argument must be operation type".to_string(),
+                ));
+            }
+        };
+
+        let sql = if args_vec.len() > 1 {
+            match &args_vec[1] {
+                LuaValue::String(s) => s.to_str()?.to_string(),
+                _ => String::new(),
+            }
+        } else {
+            String::new()
+        };
+
+        // Check if we should yield for async behavior
+        let should_yield = should_yield_for_io(lua)?;
+
+        // Execute the operation
+        let result = match operation.as_str() {
+            "insert" => {
+                let table_name = if args_vec.len() > 3 {
+                    match &args_vec[3] {
+                        LuaValue::String(s) => s.to_str()?.to_string(),
+                        _ => String::new(),
+                    }
+                } else {
+                    String::new()
+                };
+
+                let data = if args_vec.len() > 2 {
+                    args_vec[2].clone()
+                } else {
+                    LuaValue::Nil
+                };
+
+                executor.execute_insert(lua, &sql, &table_name, data)
+            }
+            "query" => {
+                let mode = if args_vec.len() > 3 {
+                    match &args_vec[3] {
+                        LuaValue::String(s) => s.to_str()?.to_string(),
+                        _ => "all".to_string(),
+                    }
+                } else {
+                    "all".to_string()
+                };
+
+                executor.execute_query(lua, &sql, &mode)
+            }
+            "update" => executor.execute_update(&sql),
+            "delete" => executor.execute_delete(&sql),
+            "raw" => {
+                let params = if args_vec.len() > 2 {
+                    match &args_vec[2] {
+                        LuaValue::Table(t) => Some(t.clone()),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                executor.execute_raw(lua, &sql, params)
+            }
+            _ => Err(LuaError::RuntimeError(format!(
+                "Unknown operation: {}",
+                operation
+            ))),
+        };
+
+        // Yield if running in coroutine
+        if should_yield {
+            yield_to_event_loop(lua)?;
+        }
+
+        result
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_db_module() {
+        let lua = Lua::new();
+        let db = create_db_module(&lua).unwrap();
+
+        // Check that connect function exists
+        assert!(db.get::<LuaFunction>("connect").is_ok());
+
+        // Check that aggregate functions exist
+        assert!(db.get::<LuaFunction>("sum").is_ok());
+        assert!(db.get::<LuaFunction>("count").is_ok());
+        assert!(db.get::<LuaFunction>("avg").is_ok());
+        assert!(db.get::<LuaFunction>("min").is_ok());
+        assert!(db.get::<LuaFunction>("max").is_ok());
+    }
+
+    #[test]
+    fn test_connect_memory() {
+        let lua = Lua::new();
+        let db = create_db_module(&lua).unwrap();
+        lua.globals().set("db_module", db).unwrap();
+
+        let result: LuaTable = lua
+            .load(
+                r#"
+            local db = db_module.connect()
+            return db
+        "#,
+            )
+            .eval()
+            .unwrap();
+
+        // Should have _executor
+        assert!(result.get::<LuaFunction>("_executor").is_ok());
+    }
+}

--- a/rover-db/src/migration.rs
+++ b/rover-db/src/migration.rs
@@ -1,0 +1,293 @@
+use crate::connection::Connection;
+use mlua::prelude::*;
+use mlua::{Lua, LuaError, LuaFunction, LuaTable};
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use crate::connection::Connection;
+
+/// Migration tracking table
+const MIGRATIONS_TABLE: &str = "_rover_migrations";
+
+/// Migration executor
+pub struct MigrationExecutor {
+    conn: Arc<Mutex<Connection>>,
+    executor: Arc<Mutex<Connection>>,
+}
+
+impl MigrationExecutor {
+    pub fn new(conn: Arc<Mutex<Connection>>, executor: Arc<Mutex<Connection>>) -> Self {
+        Self { conn, executor }
+    }
+
+impl MigrationExecutor {
+    pub fn new(conn: Arc<Mutex<Connection>>, executor: Arc<Mutex<Connection>>) -> Self {
+        Self { conn, executor }
+    }
+
+impl MigrationExecutor {
+    pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
+        Self { conn }
+    }
+
+    /// Ensure migrations table exists
+    pub fn ensure_migrations_table(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let conn = self.conn.blocking_lock();
+        let check_sql = format!(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='{}'",
+            MIGRATIONS_TABLE
+        );
+
+        let exists = conn
+            .query(&check_sql)
+            .map(|rows| !rows.is_empty())
+            .map_err(|e| format!("Failed to check migrations table: {}", e))?;
+
+        if !exists {
+            let create_sql = format!(
+                "CREATE TABLE {} (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT UNIQUE NOT NULL,
+                    applied_at TEXT NOT NULL
+                )",
+                MIGRATIONS_TABLE
+            );
+            conn.execute(&create_sql)
+                .map_err(|e| format!("Failed to create migrations table: {}", e))?;
+            println!("✅ Created migrations table");
+        }
+
+        Ok(())
+    }
+
+    /// Get all applied migrations
+    pub fn get_applied_migrations(&self) -> Result<BTreeSet<String>, Box<dyn std::error::Error>> {
+        let conn = self.conn.blocking_lock();
+        let sql = format!("SELECT name FROM {} ORDER BY id ASC", MIGRATIONS_TABLE);
+
+        let rows = conn
+            .query(&sql)
+            .map_err(|e| format!("Failed to get applied migrations: {}", e))?;
+
+        let applied: BTreeSet<String> = rows
+            .into_iter()
+            .filter_map(|row| row.get(1).and_then(|v| v.as_str().map(|s| s.to_string())))
+            .collect();
+
+        Ok(applied)
+    }
+
+    /// Record a migration as applied
+    pub fn record_migration(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let conn = self.conn.blocking_lock();
+        let sql = format!(
+            "INSERT INTO {} (name, applied_at) VALUES (?, datetime('now'))",
+            MIGRATIONS_TABLE
+        );
+
+        conn.execute(&sql)
+            .map_err(|e| format!("Failed to record migration: {}", e))?;
+
+        println!("✅ Applied migration: {}", name);
+        Ok(())
+    }
+
+    /// Remove a migration from applied list
+    pub fn remove_migration(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let conn = self.conn.blocking_lock();
+        let sql = format!("DELETE FROM {} WHERE name = ?", MIGRATIONS_TABLE);
+
+        conn.execute(&sql)
+            .map_err(|e| format!("Failed to remove migration: {}", e))?;
+
+        println!("✅ Rolled back migration: {}", name);
+        Ok(())
+    }
+
+    /// Generate reverse SQL for an operation
+    fn generate_reverse(op: &MigrationOperation) -> Result<Vec<String>, String> {
+        match op.r#type.as_str() {
+            "create_table" => {
+                let table = op.table.as_ref().unwrap_or(&String::new());
+                Ok(vec![format!("DROP TABLE {}", table)])
+            }
+            "add_column" => {
+                let table = op.table.as_ref().unwrap_or(&String::new());
+                let col = op.column.as_ref().unwrap_or(&String::new());
+                Ok(vec![format!("ALTER TABLE {} DROP COLUMN {}", table, col)])
+            }
+            "create_index" => Ok(vec![format!(
+                "DROP INDEX {}",
+                op.name.as_ref().unwrap_or(&String::new())
+            )]),
+            _ => Err(format!("Cannot auto-reverse operation: {}", op.r#type)),
+        }
+    }
+
+    /// Execute SQL migration (handles SQLite limitations)
+    pub fn execute_sql_migration(&self, sql: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let conn = self.conn.blocking_lock();
+        conn.execute(sql)
+            .map_err(|e| format!("Migration failed: {}", e))?;
+        Ok(())
+    }
+}
+
+/// Recorded migration operation
+#[derive(Debug, Clone)]
+pub struct MigrationOperation {
+    r#type: String,
+    table: Option<String>,
+    column: Option<String>,
+    name: Option<String>,
+    old_column: Option<String>,
+    new_column: Option<String>,
+    old_table: Option<String>,
+    new_table: Option<String>,
+    columns: Option<Vec<String>>,
+    sql: Option<String>,
+}
+
+/// Load and execute a migration file
+pub fn load_and_run_migration(
+    lua: &Lua,
+    executor: Arc<Mutex<Connection>>,
+    path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read migration file: {}", e))?;
+
+    // Extract filename for display
+    let filename = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("migration");
+
+    // Load the migration and call change/up/down functions
+    lua.load(&content)
+        .set_name(filename)
+        .eval::<()>()
+        .map_err(|e| format!("Migration error: {}", e))?;
+
+    Ok(())
+}
+
+/// Execute auto-reverse of operations
+pub fn execute_auto_reverse(
+    lua: &Lua,
+    executor: Arc<Mutex<Connection>>,
+    operations: Vec<MigrationOperation>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut reversed_operations = Vec::new();
+
+    for op in operations.into_iter().rev() {
+        let reverse_sqls = MigrationExecutor::new(executor.clone()).generate_reverse(&op)?;
+
+        let conn = executor.clone().blocking_lock();
+        for sql in reverse_sqls {
+            conn.execute(&sql)
+                .map_err(|e| format!("Rollback failed: {}", e))?;
+        }
+
+        reversed_operations.push(op.clone());
+    }
+
+    Ok(())
+}
+
+/// Run all pending migrations
+pub fn run_pending_migrations(
+    lua: &Lua,
+    executor: Arc<Mutex<Connection>>,
+    migrations_dir: &Path,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let applied = MigrationExecutor::new(executor.clone()).get_applied_migrations()?;
+
+    let mut pending: Vec<String> = Vec::new();
+
+    // Load migration files
+    if migrations_dir.exists() {
+        let entries = fs::read_dir(migrations_dir)
+            .map_err(|e| format!("Failed to read migrations directory: {}", e))?;
+
+        for entry in entries {
+            let path = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+
+            if path.extension().and_then(|s| s.to_str()) == Some("lua") {
+                let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+
+                // Extract migration name (without .lua)
+                let migration_name = filename.strip_suffix(".lua").unwrap_or(filename);
+
+                if !applied.contains(migration_name) {
+                    pending.push(migration_name.to_string());
+                }
+            }
+        }
+    }
+
+    if pending.is_empty() {
+        println!("✓ All migrations are up to date");
+        return Ok(0);
+    }
+
+    // Sort pending by filename
+    pending.sort();
+    pending.dedup();
+
+    println!("📋 {} pending migration(s):", pending.len());
+
+    for migration_name in &pending {
+        let path = migrations_dir.join(format!("{}.lua", migration_name));
+        load_and_run_migration(lua, executor.clone(), &path)?;
+    }
+
+    Ok(pending.len())
+}
+
+/// Rollback last N migrations
+pub fn rollback_migrations(
+    lua: &Lua,
+    executor: Arc<Mutex<Connection>>,
+    migrations_dir: &Path,
+    steps: usize,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let executor_inst = MigrationExecutor::new(conn, executor);
+    let applied = executor_inst.get_applied_migrations()?;
+
+    if applied.is_empty() {
+        println!("✓ No migrations to rollback");
+        return Ok(0);
+    }
+
+    let mut to_rollback: Vec<String> = applied.into_iter().rev().take(steps).collect();
+
+    println!("🔄 Rolling back {} migration(s):", to_rollback.len());
+
+    for migration_name in &to_rollback {
+        let path = migrations_dir.join(format!("{}.lua", migration_name));
+
+        // Load migration to get operations
+        let content = fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read migration file: {}", e))?;
+
+        // Call migration.change() to get recorded operations
+        let operations: LuaTable = lua
+            .load(&content)
+            .set_name(migration_name)
+            .call::<LuaTable>(LuaFunction::named("change"))?;
+
+        // Extract operations array
+        let ops_list: Vec<MigrationOperation> = operations
+            .get("get_operations")
+            .and_then(|f| f.call::<LuaTable>(LuaFunction::named("get_operations")))
+            .map_err(|e| format!("Failed to get operations: {}", e))?;
+
+        execute_auto_reverse(lua, executor.clone(), ops_list)?;
+
+        executor_inst.remove_migration(migration_name)?;
+    }
+
+    Ok(to_rollback.len())
+}

--- a/rover-db/src/migration_dsl.lua
+++ b/rover-db/src/migration_dsl.lua
@@ -1,0 +1,130 @@
+-- Rover Migration DSL
+-- Provides migration.<table>:operation() syntax and change/up/down functions
+
+local MigrationDSL = {}
+
+-- Current migration being executed
+local current_migration = nil
+local migration_operations = {}
+
+-- Record operations for change() auto-reverse
+function MigrationDSL.record_operation(operation)
+    table.insert(migration_operations, operation)
+end
+
+function MigrationDSL.get_operations()
+    return migration_operations
+end
+
+function MigrationDSL.clear_operations()
+    migration_operations = {}
+end
+
+-- Table operations context
+local function create_table_context(table_name)
+    return {
+        _table_name = table_name,
+
+        create = function(self, definition)
+            MigrationDSL.record_operation({
+                type = "create_table",
+                table = table_name,
+                definition = definition,
+            })
+            return self
+        end,
+
+        drop = function(self)
+            MigrationDSL.record_operation({
+                type = "drop_table",
+                table = table_name,
+            })
+            return self
+        end,
+
+        add_column = function(self, column_name, column_type)
+            MigrationDSL.record_operation({
+                type = "add_column",
+                table = table_name,
+                column = column_name,
+                column_type = column_type,
+            })
+            return self
+        end,
+
+        remove_column = function(self, column_name)
+            MigrationDSL.record_operation({
+                type = "remove_column",
+                table = table_name,
+                column = column_name,
+            })
+            return self
+        end,
+
+        rename_column = function(self, old_name, new_name)
+            MigrationDSL.record_operation({
+                type = "rename_column",
+                table = table_name,
+                old_column = old_name,
+                new_column = new_name,
+            })
+            return self
+        end,
+
+        create_index = function(self, index_name, columns)
+            MigrationDSL.record_operation({
+                type = "create_index",
+                table = table_name,
+                index = index_name,
+                columns = columns,
+            })
+            return self
+        end,
+
+        drop_index = function(self, index_name)
+            MigrationDSL.record_operation({
+                type = "drop_index",
+                table = table_name,
+                index = index_name,
+            })
+            return self
+        end,
+
+        rename = function(self, new_name)
+            MigrationDSL.record_operation({
+                type = "rename_table",
+                table = table_name,
+                new_table = new_name,
+            })
+            return self
+        end,
+    }
+end
+
+-- Metatable for dynamic table access: migration.<table>
+local migration_mt = {
+    __index = function(self, table_name)
+        return create_table_context(table_name)
+    end,
+}
+
+setmetatable(MigrationDSL, migration_mt)
+
+-- Raw SQL escape hatch
+function MigrationDSL.raw(sql)
+    MigrationDSL.record_operation({
+        type = "raw",
+        sql = sql,
+    })
+end
+
+-- Helper to execute change/up/down functions
+function MigrationDSL.execute_migration_function(migration_fn_name, migration_fn)
+    MigrationDSL.clear_operations()
+    if migration_fn then
+        migration_fn()
+    end
+    return MigrationDSL.get_operations()
+end
+
+return MigrationDSL

--- a/rover-db/src/schema.rs
+++ b/rover-db/src/schema.rs
@@ -37,7 +37,10 @@ impl SchemaManager {
     }
 
     /// Infer schema from a Lua table
-    pub fn infer_schema_from_lua(&self, data: &LuaTable) -> Result<Vec<InferredColumn>, SchemaError> {
+    pub fn infer_schema_from_lua(
+        &self,
+        data: &LuaTable,
+    ) -> Result<Vec<InferredColumn>, SchemaError> {
         let mut columns = Vec::new();
 
         // Check if 'id' field exists, if not we'll add it as auto-increment primary key
@@ -148,7 +151,11 @@ impl SchemaManager {
                 table_name,
                 col.name,
                 col.sql_type,
-                if col.nullable { "" } else { " NOT NULL DEFAULT ''" }
+                if col.nullable {
+                    ""
+                } else {
+                    " NOT NULL DEFAULT ''"
+                }
             );
 
             conn.execute(&sql)
@@ -178,7 +185,7 @@ fn infer_sql_type(value: &LuaValue) -> String {
             "TEXT".to_string()
         }
         LuaValue::Table(_) => "TEXT".to_string(), // JSON-serialize tables
-        LuaValue::Nil => "TEXT".to_string(),       // Default to TEXT for nil
+        LuaValue::Nil => "TEXT".to_string(),      // Default to TEXT for nil
         _ => "TEXT".to_string(),
     }
 }

--- a/rover-db/src/schema.rs
+++ b/rover-db/src/schema.rs
@@ -1,0 +1,302 @@
+//! Schema inference and migration management
+//!
+//! Infers database schema from Lua data and handles automatic migrations.
+
+use crate::connection::Connection;
+use mlua::prelude::*;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::sync::Mutex;
+
+#[derive(Error, Debug)]
+pub enum SchemaError {
+    #[error("Type inference failed: {0}")]
+    TypeInference(String),
+    #[error("Migration failed: {0}")]
+    Migration(String),
+}
+
+/// Represents an inferred column schema
+#[derive(Debug, Clone)]
+pub struct InferredColumn {
+    pub name: String,
+    pub sql_type: String,
+    pub nullable: bool,
+    pub primary_key: bool,
+}
+
+/// Schema manager for inference and migrations
+pub struct SchemaManager {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl SchemaManager {
+    /// Create a new schema manager
+    pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
+        Self { conn }
+    }
+
+    /// Infer schema from a Lua table
+    pub fn infer_schema_from_lua(&self, data: &LuaTable) -> Result<Vec<InferredColumn>, SchemaError> {
+        let mut columns = Vec::new();
+
+        // Check if 'id' field exists, if not we'll add it as auto-increment primary key
+        let has_id = data.get::<LuaValue>("id").is_ok()
+            && !matches!(data.get::<LuaValue>("id"), Ok(LuaValue::Nil));
+
+        if !has_id {
+            columns.push(InferredColumn {
+                name: "id".to_string(),
+                sql_type: "INTEGER".to_string(),
+                nullable: false,
+                primary_key: true,
+            });
+        }
+
+        // Iterate through table keys
+        for pair in data.clone().pairs::<String, LuaValue>() {
+            let (key, value) = pair.map_err(|e| SchemaError::TypeInference(e.to_string()))?;
+
+            let sql_type = infer_sql_type(&value);
+            let is_primary_key = key == "id";
+
+            columns.push(InferredColumn {
+                name: key,
+                sql_type,
+                nullable: !is_primary_key, // Only id is NOT NULL by default
+                primary_key: is_primary_key,
+            });
+        }
+
+        // Sort columns to ensure 'id' comes first
+        columns.sort_by(|a, b| {
+            if a.name == "id" {
+                std::cmp::Ordering::Less
+            } else if b.name == "id" {
+                std::cmp::Ordering::Greater
+            } else {
+                a.name.cmp(&b.name)
+            }
+        });
+
+        Ok(columns)
+    }
+
+    /// Generate CREATE TABLE SQL from inferred schema
+    pub fn generate_create_table(&self, table_name: &str, columns: &[InferredColumn]) -> String {
+        let mut column_defs = Vec::new();
+
+        for col in columns {
+            let mut def = format!("{} {}", col.name, col.sql_type);
+
+            if col.primary_key {
+                def.push_str(" PRIMARY KEY");
+                if col.sql_type == "INTEGER" {
+                    def.push_str(" AUTOINCREMENT");
+                }
+            }
+
+            if !col.nullable && !col.primary_key {
+                def.push_str(" NOT NULL");
+            }
+
+            column_defs.push(def);
+        }
+
+        format!(
+            "CREATE TABLE IF NOT EXISTS {} ({})",
+            table_name,
+            column_defs.join(", ")
+        )
+    }
+
+    /// Check if a table needs migration (new columns added)
+    pub fn check_migration_needed(
+        &self,
+        table_name: &str,
+        new_columns: &[InferredColumn],
+    ) -> Result<Vec<InferredColumn>, SchemaError> {
+        let conn = self.conn.blocking_lock();
+
+        let existing_schema = conn
+            .get_table_schema(table_name)
+            .map_err(|e| SchemaError::Migration(e.to_string()))?;
+
+        let existing_names: std::collections::HashSet<String> =
+            existing_schema.iter().map(|c| c.name.clone()).collect();
+
+        let missing_columns: Vec<InferredColumn> = new_columns
+            .iter()
+            .filter(|c| !existing_names.contains(&c.name))
+            .cloned()
+            .collect();
+
+        Ok(missing_columns)
+    }
+
+    /// Apply migration (add missing columns)
+    pub fn apply_migration(
+        &self,
+        table_name: &str,
+        new_columns: &[InferredColumn],
+    ) -> Result<(), SchemaError> {
+        let conn = self.conn.blocking_lock();
+
+        for col in new_columns {
+            let sql = format!(
+                "ALTER TABLE {} ADD COLUMN {} {}{}",
+                table_name,
+                col.name,
+                col.sql_type,
+                if col.nullable { "" } else { " NOT NULL DEFAULT ''" }
+            );
+
+            conn.execute(&sql)
+                .map_err(|e| SchemaError::Migration(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Infer SQL type from Lua value
+fn infer_sql_type(value: &LuaValue) -> String {
+    match value {
+        LuaValue::Integer(_) => "INTEGER".to_string(),
+        LuaValue::Number(_) => "REAL".to_string(),
+        LuaValue::Boolean(_) => "INTEGER".to_string(), // SQLite uses INTEGER for boolean
+        LuaValue::String(s) => {
+            // Try to detect date/datetime patterns
+            if let Ok(s_str) = s.to_str() {
+                if is_datetime_string(&s_str) {
+                    return "DATETIME".to_string();
+                }
+                if is_date_string(&s_str) {
+                    return "DATE".to_string();
+                }
+            }
+            "TEXT".to_string()
+        }
+        LuaValue::Table(_) => "TEXT".to_string(), // JSON-serialize tables
+        LuaValue::Nil => "TEXT".to_string(),       // Default to TEXT for nil
+        _ => "TEXT".to_string(),
+    }
+}
+
+/// Check if string looks like a datetime
+fn is_datetime_string(s: &str) -> bool {
+    // ISO 8601 datetime pattern: YYYY-MM-DDTHH:MM:SS
+    let parts: Vec<&str> = s.split(['T', ' ']).collect();
+    if parts.len() >= 2 {
+        return is_date_string(parts[0]) && is_time_string(parts[1]);
+    }
+    false
+}
+
+/// Check if string looks like a date
+fn is_date_string(s: &str) -> bool {
+    // Simple date pattern: YYYY-MM-DD
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() == 3 {
+        return parts[0].len() == 4
+            && parts[1].len() == 2
+            && parts[2].len() >= 2
+            && parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit()));
+    }
+    false
+}
+
+/// Check if string looks like a time
+fn is_time_string(s: &str) -> bool {
+    // Simple time pattern: HH:MM:SS or HH:MM
+    let s = s.split('.').next().unwrap_or(s); // Remove milliseconds
+    let s = s.split(['+', '-', 'Z']).next().unwrap_or(s); // Remove timezone
+    let parts: Vec<&str> = s.split(':').collect();
+    parts.len() >= 2 && parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_infer_sql_type() {
+        assert_eq!(infer_sql_type(&LuaValue::Integer(42)), "INTEGER");
+        assert_eq!(infer_sql_type(&LuaValue::Number(3.14)), "REAL");
+        assert_eq!(infer_sql_type(&LuaValue::Boolean(true)), "INTEGER");
+    }
+
+    #[test]
+    fn test_is_date_string() {
+        assert!(is_date_string("2024-01-15"));
+        assert!(!is_date_string("not-a-date"));
+        assert!(!is_date_string("2024/01/15"));
+    }
+
+    #[test]
+    fn test_is_datetime_string() {
+        assert!(is_datetime_string("2024-01-15T10:30:00"));
+        assert!(is_datetime_string("2024-01-15 10:30:00"));
+        assert!(!is_datetime_string("2024-01-15"));
+    }
+
+    #[test]
+    fn test_schema_inference() {
+        let lua = Lua::new();
+        let data = lua.create_table().unwrap();
+        data.set("name", "Alice").unwrap();
+        data.set("age", 30).unwrap();
+        data.set("score", 95.5).unwrap();
+        data.set("active", true).unwrap();
+
+        let conn = Connection::new(":memory:").unwrap();
+        let conn = Arc::new(Mutex::new(conn));
+        let manager = SchemaManager::new(conn);
+
+        let schema = manager.infer_schema_from_lua(&data).unwrap();
+
+        // Should have 5 columns: id (auto-added) + 4 from data
+        assert_eq!(schema.len(), 5);
+
+        // id should be first and primary key
+        assert_eq!(schema[0].name, "id");
+        assert!(schema[0].primary_key);
+
+        // Find other columns
+        let name_col = schema.iter().find(|c| c.name == "name").unwrap();
+        assert_eq!(name_col.sql_type, "TEXT");
+
+        let age_col = schema.iter().find(|c| c.name == "age").unwrap();
+        assert_eq!(age_col.sql_type, "INTEGER");
+
+        let score_col = schema.iter().find(|c| c.name == "score").unwrap();
+        assert_eq!(score_col.sql_type, "REAL");
+    }
+
+    #[test]
+    fn test_generate_create_table() {
+        let conn = Connection::new(":memory:").unwrap();
+        let conn = Arc::new(Mutex::new(conn));
+        let manager = SchemaManager::new(conn);
+
+        let columns = vec![
+            InferredColumn {
+                name: "id".to_string(),
+                sql_type: "INTEGER".to_string(),
+                nullable: false,
+                primary_key: true,
+            },
+            InferredColumn {
+                name: "name".to_string(),
+                sql_type: "TEXT".to_string(),
+                nullable: true,
+                primary_key: false,
+            },
+        ];
+
+        let sql = manager.generate_create_table("users", &columns);
+        assert!(sql.contains("CREATE TABLE IF NOT EXISTS users"));
+        assert!(sql.contains("id INTEGER PRIMARY KEY AUTOINCREMENT"));
+        assert!(sql.contains("name TEXT"));
+    }
+}

--- a/rover-db/src/schema_analyzer.rs
+++ b/rover-db/src/schema_analyzer.rs
@@ -1,0 +1,305 @@
+//! Schema loader - loads and executes schema Lua files
+//!
+//! Loads db/schemas/*.lua files and extracts table definitions.
+
+use mlua::prelude::*;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+/// Load all schema files from a directory (creates its own Lua instance)
+pub fn load_schemas_from_dir(schemas_dir: &Path) -> Result<HashMap<String, TableDefinition>, String> {
+    let lua = Lua::new();
+    load_schemas(&lua, schemas_dir)
+}
+
+/// Load all schema files from a directory and return table definitions
+pub fn load_schemas(
+    lua: &Lua,
+    schemas_dir: &Path,
+) -> Result<HashMap<String, TableDefinition>, String> {
+    let mut schemas = HashMap::new();
+
+    if !schemas_dir.exists() {
+        return Ok(schemas);
+    }
+
+    // Get the schema DSL
+    let schema_dsl: LuaTable = lua
+        .load(include_str!("schema_dsl.lua"))
+        .set_name("schema_dsl.lua")
+        .eval()
+        .map_err(|e| format!("Failed to load schema DSL: {}", e))?;
+
+    // Clear any existing schemas
+    let clear_fn: LuaFunction = schema_dsl
+        .get("clear")
+        .map_err(|e| format!("Failed to get clear function: {}", e))?;
+    clear_fn
+        .call::<()>(())
+        .map_err(|e| format!("Failed to clear schemas: {}", e))?;
+
+    // Load guard module for schema field types
+    let guard: LuaTable = lua
+        .load(include_str!("guard.lua"))
+        .set_name("guard.lua")
+        .eval()
+        .map_err(|e| format!("Failed to load guard: {}", e))?;
+
+    // Make schema DSL available globally as rover.db.schema and guard
+    let globals = lua.globals();
+    globals
+        .set("guard", guard)
+        .map_err(|e| format!("Failed to set guard: {}", e))?;
+
+    let rover: LuaTable = globals
+        .get("rover")
+        .unwrap_or_else(|_| lua.create_table().unwrap());
+    let db: LuaTable = rover
+        .get("db")
+        .unwrap_or_else(|_| lua.create_table().unwrap());
+    db.set("schema", schema_dsl.clone())
+        .map_err(|e| format!("Failed to set schema: {}", e))?;
+    rover
+        .set("db", db)
+        .map_err(|e| format!("Failed to set db: {}", e))?;
+    globals
+        .set("rover", rover)
+        .map_err(|e| format!("Failed to set rover: {}", e))?;
+
+    // Load each schema file
+    let entries =
+        fs::read_dir(schemas_dir).map_err(|e| format!("Failed to read schemas dir: {}", e))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("lua") {
+            let content = fs::read_to_string(&path)
+                .map_err(|e| format!("Failed to read {:?}: {}", path, e))?;
+
+            let filename = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("schema");
+
+            lua.load(&content)
+                .set_name(filename)
+                .exec()
+                .map_err(|e| format!("Failed to execute {:?}: {}", path, e))?;
+        }
+    }
+
+    // Extract registered schemas
+    let get_all_fn: LuaFunction = schema_dsl
+        .get("get_all")
+        .map_err(|e| format!("Failed to get get_all function: {}", e))?;
+
+    let all_schemas: LuaTable = get_all_fn
+        .call(())
+        .map_err(|e| format!("Failed to get all schemas: {}", e))?;
+
+    // Convert Lua schemas to Rust structs
+    for pair in all_schemas.pairs::<String, LuaTable>() {
+        let (table_name, definition) =
+            pair.map_err(|e| format!("Failed to iterate schemas: {}", e))?;
+
+        let table_def = parse_table_definition(&definition)?;
+        schemas.insert(table_name, table_def);
+    }
+
+    Ok(schemas)
+}
+
+/// Parse a Lua table definition into a Rust struct
+fn parse_table_definition(definition: &LuaTable) -> Result<TableDefinition, String> {
+    let mut fields = Vec::new();
+
+    for pair in definition.clone().pairs::<String, LuaValue>() {
+        let (field_name, field_def) =
+            pair.map_err(|e| format!("Failed to iterate definition: {}", e))?;
+
+        let field = parse_field_definition(&field_name, &field_def)?;
+        fields.push(field);
+    }
+
+    // Sort fields so id comes first
+    fields.sort_by(|a, b| {
+        if a.name == "id" {
+            std::cmp::Ordering::Less
+        } else if b.name == "id" {
+            std::cmp::Ordering::Greater
+        } else {
+            a.name.cmp(&b.name)
+        }
+    });
+
+    Ok(TableDefinition { fields })
+}
+
+/// Parse a field definition from Lua guard type
+fn parse_field_definition(name: &str, value: &LuaValue) -> Result<FieldDefinition, String> {
+    let mut field = FieldDefinition {
+        name: name.to_string(),
+        field_type: FieldType::Text,
+        nullable: true, // Default nullable
+        primary_key: false,
+        auto_increment: false,
+        unique: false,
+        references: None,
+        indexed: false,
+    };
+
+    match value {
+        LuaValue::Table(t) => {
+            // Extract type from guard table (uses _type field)
+            if let Ok(type_str) = t.get::<String>("_type") {
+                field.field_type = FieldType::from_str(&type_str);
+            }
+
+            // Check modifiers (guard uses _prefixed fields)
+            if let Ok(true) = t.get::<bool>("_primary") {
+                field.primary_key = true;
+                field.nullable = false;
+            }
+            if let Ok(true) = t.get::<bool>("_auto") {
+                field.auto_increment = true;
+            }
+            if let Ok(true) = t.get::<bool>("_unique") {
+                field.unique = true;
+            }
+            if let Ok(true) = t.get::<bool>("_required") {
+                field.nullable = false;
+            }
+            if let Ok(false) = t.get::<bool>("_nullable") {
+                field.nullable = false;
+            }
+            if let Ok(true) = t.get::<bool>("_index") {
+                field.indexed = true;
+            }
+            if let Ok(ref_str) = t.get::<String>("_references") {
+                // Parse "table.column" format
+                if let Some((table, col)) = ref_str.split_once('.') {
+                    field.references = Some(ForeignKey {
+                        table: table.to_string(),
+                        column: col.to_string(),
+                    });
+                }
+            }
+        }
+        LuaValue::String(s) => {
+            // Simple type string
+            if let Ok(type_str) = s.to_str() {
+                field.field_type = FieldType::from_str(&type_str);
+            }
+        }
+        _ => {}
+    }
+
+    Ok(field)
+}
+
+/// Table definition
+#[derive(Debug, Clone)]
+pub struct TableDefinition {
+    pub fields: Vec<FieldDefinition>,
+}
+
+/// Field definition
+#[derive(Debug, Clone)]
+pub struct FieldDefinition {
+    pub name: String,
+    pub field_type: FieldType,
+    pub nullable: bool,
+    pub primary_key: bool,
+    pub auto_increment: bool,
+    pub unique: bool,
+    pub references: Option<ForeignKey>,
+    pub indexed: bool,
+}
+
+/// Foreign key reference
+#[derive(Debug, Clone)]
+pub struct ForeignKey {
+    pub table: String,
+    pub column: String,
+}
+
+/// Field types
+#[derive(Debug, Clone, PartialEq)]
+pub enum FieldType {
+    Integer,
+    Text,
+    Real,
+    Boolean,
+    Datetime,
+    Date,
+    Blob,
+}
+
+impl FieldType {
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "integer" | "int" => FieldType::Integer,
+            "real" | "float" | "double" | "number" => FieldType::Real,
+            "boolean" | "bool" => FieldType::Boolean,
+            "datetime" => FieldType::Datetime,
+            "date" => FieldType::Date,
+            "blob" => FieldType::Blob,
+            _ => FieldType::Text,
+        }
+    }
+
+    pub fn to_sql(&self) -> &'static str {
+        match self {
+            FieldType::Integer => "INTEGER",
+            FieldType::Text => "TEXT",
+            FieldType::Real => "REAL",
+            FieldType::Boolean => "INTEGER",
+            FieldType::Datetime => "DATETIME",
+            FieldType::Date => "DATE",
+            FieldType::Blob => "BLOB",
+        }
+    }
+}
+
+/// Generate CREATE TABLE SQL from definition
+pub fn generate_create_table(table_name: &str, def: &TableDefinition) -> String {
+    let mut columns = Vec::new();
+    let mut constraints = Vec::new();
+
+    for field in &def.fields {
+        let mut col = format!("{} {}", field.name, field.field_type.to_sql());
+
+        if field.primary_key {
+            col.push_str(" PRIMARY KEY");
+            if field.auto_increment && field.field_type == FieldType::Integer {
+                col.push_str(" AUTOINCREMENT");
+            }
+        }
+
+        if !field.nullable && !field.primary_key {
+            col.push_str(" NOT NULL");
+        }
+
+        if field.unique && !field.primary_key {
+            col.push_str(" UNIQUE");
+        }
+
+        columns.push(col);
+
+        if let Some(ref fk) = field.references {
+            constraints.push(format!(
+                "FOREIGN KEY ({}) REFERENCES {}({})",
+                field.name, fk.table, fk.column
+            ));
+        }
+    }
+
+    columns.extend(constraints);
+
+    format!(
+        "CREATE TABLE IF NOT EXISTS {} (\n  {}\n)",
+        table_name,
+        columns.join(",\n  ")
+    )
+}

--- a/rover-db/src/schema_analyzer.rs
+++ b/rover-db/src/schema_analyzer.rs
@@ -8,7 +8,9 @@ use std::fs;
 use std::path::Path;
 
 /// Load all schema files from a directory (creates its own Lua instance)
-pub fn load_schemas_from_dir(schemas_dir: &Path) -> Result<HashMap<String, TableDefinition>, String> {
+pub fn load_schemas_from_dir(
+    schemas_dir: &Path,
+) -> Result<HashMap<String, TableDefinition>, String> {
     let lua = Lua::new();
     load_schemas(&lua, schemas_dir)
 }

--- a/rover-db/src/schema_dsl.lua
+++ b/rover-db/src/schema_dsl.lua
@@ -1,0 +1,38 @@
+-- Rover Schema DSL
+-- Provides rover.schema.<table> { field = type } syntax
+
+local SchemaDSL = {}
+
+-- Global schema definitions (stored during load)
+local schemas = {}
+
+function SchemaDSL.register(table_name, definition)
+    schemas[table_name] = definition
+    return definition
+end
+
+function SchemaDSL.get_all()
+    return schemas
+end
+
+function SchemaDSL.get(table_name)
+    return schemas[table_name]
+end
+
+function SchemaDSL.clear()
+    schemas = {}
+end
+
+-- Metatable for dynamic table access: rover.schema.users {...}
+local schema_mt = {
+    __index = function(self, table_name)
+        return function(definition)
+            SchemaDSL.register(table_name, definition)
+            return definition
+        end
+    end,
+}
+
+setmetatable(SchemaDSL, schema_mt)
+
+return SchemaDSL

--- a/rover-db/src/schema_dsl.lua
+++ b/rover-db/src/schema_dsl.lua
@@ -1,13 +1,107 @@
 -- Rover Schema DSL
 -- Provides rover.schema.<table> { field = type } syntax
+-- Generates schema-aware query methods when schemas are registered
 
 local SchemaDSL = {}
 
 -- Global schema definitions (stored during load)
 local schemas = {}
 
+-- Generated query methods per table (from schema fields)
+local table_query_methods = {}
+
+-- Operators mapping (mirrors db.lua OPERATORS)
+local OPERATORS = {
+    equals = "=",
+    not_equals = "!=",
+    bigger_than = ">",
+    smaller_than = "<",
+    bigger_than_or_equals = ">=",
+    smaller_than_or_equals = "<=",
+    contains = "LIKE",
+    starts_with = "LIKE",
+    ends_with = "LIKE",
+    between = "BETWEEN",
+    in_list = "IN",
+    not_in_list = "NOT IN",
+    is_null = "IS NULL",
+    is_not_null = "IS NOT NULL",
+}
+
+-- Extract field names from a schema definition
+-- Schema fields can be guard validators or simple values
+local function extract_field_names(definition)
+    local fields = {}
+    for field_name, _ in pairs(definition) do
+        -- Skip internal fields (starting with _)
+        if type(field_name) == "string" and not field_name:match("^_") then
+            table.insert(fields, field_name)
+        end
+    end
+    return fields
+end
+
+-- Generate filter methods for a field
+local function generate_field_methods(field_name)
+    local methods = {}
+
+    -- by_<field>(value) - equals
+    methods["by_" .. field_name] = function(self, value)
+        return self:_add_filter(field_name, "equals", value)
+    end
+
+    -- by_<field>_<operator>(value) - for each operator
+    for op_name, _ in pairs(OPERATORS) do
+        local method_name = "by_" .. field_name .. "_" .. op_name
+        methods[method_name] = function(self, value)
+            return self:_add_filter(field_name, op_name, value)
+        end
+    end
+
+    return methods
+end
+
+-- Generate preload methods from relations
+local function generate_preload_methods(definition)
+    local methods = {}
+
+    -- Check for _relations in definition
+    if definition._relations then
+        for relation_name, _ in pairs(definition._relations) do
+            methods["with_" .. relation_name] = function(self)
+                local new_query = self:_clone()
+                table.insert(new_query._preloads, relation_name)
+                return new_query
+            end
+        end
+    end
+
+    return methods
+end
+
 function SchemaDSL.register(table_name, definition)
     schemas[table_name] = definition
+
+    -- Generate filter methods for each field
+    local query_methods = {}
+    local fields = extract_field_names(definition)
+
+    for _, field_name in ipairs(fields) do
+        local field_methods = generate_field_methods(field_name)
+        for method_name, method_fn in pairs(field_methods) do
+            query_methods[method_name] = method_fn
+        end
+    end
+
+    -- Generate preload methods for relations
+    local preload_methods = generate_preload_methods(definition)
+    for method_name, method_fn in pairs(preload_methods) do
+        query_methods[method_name] = method_fn
+    end
+
+    -- Store methods for this table
+    table_query_methods[table_name] = query_methods
+
     return definition
 end
 
@@ -19,8 +113,13 @@ function SchemaDSL.get(table_name)
     return schemas[table_name]
 end
 
+function SchemaDSL.get_query_methods(table_name)
+    return table_query_methods[table_name]
+end
+
 function SchemaDSL.clear()
     schemas = {}
+    table_query_methods = {}
 end
 
 -- Metatable for dynamic table access: rover.schema.users {...}

--- a/rover-db/tests/db_test.lua
+++ b/rover-db/tests/db_test.lua
@@ -1,0 +1,723 @@
+-- rover-db Unit Tests
+-- Tests for the Intent-Based Query Builder & ORM DSL
+
+-- Test framework
+local tests_passed = 0
+local tests_failed = 0
+
+local function test(name, fn)
+    local success, err = pcall(fn)
+    if success then
+        tests_passed = tests_passed + 1
+        print("[PASS] " .. name)
+    else
+        tests_failed = tests_failed + 1
+        print("[FAIL] " .. name .. ": " .. tostring(err))
+    end
+end
+
+local function assert_equals(expected, actual, msg)
+    if expected ~= actual then
+        error((msg or "Assertion failed") .. ": expected " .. tostring(expected) .. ", got " .. tostring(actual))
+    end
+end
+
+local function assert_true(value, msg)
+    if not value then
+        error((msg or "Assertion failed") .. ": expected true, got " .. tostring(value))
+    end
+end
+
+local function assert_not_nil(value, msg)
+    if value == nil then
+        error((msg or "Assertion failed") .. ": expected non-nil value")
+    end
+end
+
+local function assert_contains(str, pattern, msg)
+    if not str:find(pattern, 1, true) then
+        error((msg or "Assertion failed") .. ": '" .. str .. "' does not contain '" .. pattern .. "'")
+    end
+end
+
+-- Load the db module directly for testing
+local DB = dofile("src/db.lua")
+
+print("========================================")
+print("Running rover-db Unit Tests")
+print("========================================\n")
+
+-- ============================================================================
+-- Phase 1: Core Tests
+-- ============================================================================
+
+print("--- Phase 1: Core Tests ---\n")
+
+test("DB.connect creates a database instance", function()
+    local db = DB.connect()
+    assert_not_nil(db)
+    assert_not_nil(db._config)
+end)
+
+test("DB instance allows dynamic table access", function()
+    local db = DB.connect()
+    local users_proxy = db.users
+    assert_not_nil(users_proxy)
+    assert_equals("table_proxy", users_proxy._type)
+    assert_equals("users", users_proxy._name)
+end)
+
+test("TableProxy returns ColumnRef on column access", function()
+    local db = DB.connect()
+    local col_ref = db.users.id
+    assert_equals("column_ref", col_ref._type)
+    assert_equals("users", col_ref._table)
+    assert_equals("id", col_ref._column)
+end)
+
+test("ColumnRef tostring works correctly", function()
+    local db = DB.connect()
+    local col_ref = db.users.id
+    assert_equals("users.id", tostring(col_ref))
+end)
+
+-- ============================================================================
+-- Phase 2: Query Object Tests
+-- ============================================================================
+
+print("\n--- Phase 2: Query Object Tests ---\n")
+
+test("find() creates a Query object", function()
+    local db = DB.connect()
+    local query = db.users:find()
+    assert_equals("query", query._type)
+    assert_equals("users", query._table)
+end)
+
+test("Query is immutable (chaining creates new objects)", function()
+    local db = DB.connect()
+    local query1 = db.users:find()
+    local query2 = query1:by_age(25)
+
+    assert_equals(0, #query1._filters)
+    assert_equals(1, #query2._filters)
+end)
+
+test("by_<field> filter (default equals)", function()
+    local db = DB.connect()
+    local query = db.users:find():by_status("active")
+
+    assert_equals(1, #query._filters)
+    assert_equals("status", query._filters[1].field)
+    assert_equals("equals", query._filters[1].operator)
+    assert_equals("active", query._filters[1].value)
+end)
+
+test("by_<field>_bigger_than filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_age_bigger_than(18)
+
+    assert_equals(1, #query._filters)
+    assert_equals("age", query._filters[1].field)
+    assert_equals("bigger_than", query._filters[1].operator)
+    assert_equals(18, query._filters[1].value)
+end)
+
+test("by_<field>_smaller_than filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_age_smaller_than(65)
+
+    assert_equals(1, #query._filters)
+    assert_equals("age", query._filters[1].field)
+    assert_equals("smaller_than", query._filters[1].operator)
+end)
+
+test("by_<field>_contains filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_name_contains("ana")
+
+    assert_equals("name", query._filters[1].field)
+    assert_equals("contains", query._filters[1].operator)
+    assert_equals("ana", query._filters[1].value)
+end)
+
+test("by_<field>_starts_with filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_email_starts_with("admin")
+
+    assert_equals("email", query._filters[1].field)
+    assert_equals("starts_with", query._filters[1].operator)
+end)
+
+test("by_<field>_ends_with filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_email_ends_with(".com")
+
+    assert_equals("email", query._filters[1].field)
+    assert_equals("ends_with", query._filters[1].operator)
+end)
+
+test("by_<field>_in_list filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_status_in_list({"active", "pending", "paid"})
+
+    assert_equals("status", query._filters[1].field)
+    assert_equals("in_list", query._filters[1].operator)
+    assert_equals(3, #query._filters[1].value)
+end)
+
+test("by_<field>_not_in_list filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_status_not_in_list({"banned", "deleted"})
+
+    assert_equals("status", query._filters[1].field)
+    assert_equals("not_in_list", query._filters[1].operator)
+end)
+
+test("by_<field>_between filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_age_between({18, 65})
+
+    assert_equals("age", query._filters[1].field)
+    assert_equals("between", query._filters[1].operator)
+    assert_equals(18, query._filters[1].value[1])
+    assert_equals(65, query._filters[1].value[2])
+end)
+
+test("by_<field>_is_null filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_deleted_at_is_null()
+
+    assert_equals("deleted_at", query._filters[1].field)
+    assert_equals("is_null", query._filters[1].operator)
+end)
+
+test("by_<field>_is_not_null filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_email_is_not_null()
+
+    assert_equals("email", query._filters[1].field)
+    assert_equals("is_not_null", query._filters[1].operator)
+end)
+
+test("Multiple filters can be chained", function()
+    local db = DB.connect()
+    local query = db.users:find()
+        :by_status("active")
+        :by_age_bigger_than(18)
+        :by_role("admin")
+
+    assert_equals(3, #query._filters)
+end)
+
+-- ============================================================================
+-- Phase 3: Subqueries and EXISTS Tests
+-- ============================================================================
+
+print("\n--- Phase 3: Subqueries and EXISTS Tests ---\n")
+
+test("Subquery can be used with by_<field>_in", function()
+    local db = DB.connect()
+
+    local active_users = db.users:find():by_status("active")
+    local query = db.posts:find():by_author_id_in_list(active_users)
+
+    assert_equals("author_id", query._filters[1].field)
+    assert_equals("in_list", query._filters[1].operator)
+    assert_equals("query", query._filters[1].value._type)
+end)
+
+test("exists() with on() creates correlated subquery", function()
+    local db = DB.connect()
+
+    local query = db.users:find()
+        :exists(db.orders:find():by_status("paid"))
+        :on(db.orders.user_id, db.users.id)
+
+    assert_equals(1, #query._exists_clauses)
+    assert_equals("query", query._exists_clauses[1].subquery._type)
+    assert_equals("orders", query._exists_clauses[1].subquery._table)
+end)
+
+test("select() for subquery projections", function()
+    local db = DB.connect()
+
+    local user_ids = db.orders:find()
+        :by_status("paid")
+        :select(db.orders.user_id)
+
+    assert_not_nil(user_ids._select_cols)
+    assert_equals(1, #user_ids._select_cols)
+end)
+
+-- ============================================================================
+-- Phase 4: OR Composition Tests (merge)
+-- ============================================================================
+
+print("\n--- Phase 4: OR Composition Tests ---\n")
+
+test("merge() combines queries with OR", function()
+    local db = DB.connect()
+
+    local admins = db.users:find():by_role("admin")
+    local minors = db.users:find():by_age_smaller_than(18)
+
+    local query = db.users:find():merge(admins, minors)
+
+    assert_equals(2, #query._merged_queries)
+end)
+
+test("any_of() is alias for merge()", function()
+    local db = DB.connect()
+
+    local admins = db.users:find():by_role("admin")
+    local minors = db.users:find():by_age_smaller_than(18)
+
+    local query = db.users:find():any_of(admins, minors)
+
+    assert_equals(2, #query._merged_queries)
+end)
+
+test("Complex OR with EXISTS", function()
+    local db = DB.connect()
+
+    local has_paid_orders = db.users:find()
+        :exists(db.orders:find():by_status("paid"))
+        :on(db.orders.user_id, db.users.id)
+
+    local has_subscription = db.users:find()
+        :exists(db.subscriptions:find():by_active(true))
+        :on(db.subscriptions.user_id, db.users.id)
+
+    local query = db.users:find():merge(has_paid_orders, has_subscription)
+
+    assert_equals(2, #query._merged_queries)
+    assert_equals(1, #query._merged_queries[1]._exists_clauses)
+    assert_equals(1, #query._merged_queries[2]._exists_clauses)
+end)
+
+-- ============================================================================
+-- Phase 5: Grouping & Aggregates Tests
+-- ============================================================================
+
+print("\n--- Phase 5: Grouping & Aggregates Tests ---\n")
+
+test("group_by() adds grouping", function()
+    local db = DB.connect()
+
+    local query = db.orders:find()
+        :group_by(db.orders.user_id)
+
+    assert_equals(1, #query._group_by_cols)
+end)
+
+test("agg() adds aggregates", function()
+    local db = DB.connect()
+
+    local query = db.orders:find()
+        :group_by(db.orders.user_id)
+        :agg({
+            total = DB.sum(db.orders.amount),
+            order_count = DB.count(db.orders.id)
+        })
+
+    assert_not_nil(query._aggregates.total)
+    assert_not_nil(query._aggregates.order_count)
+end)
+
+test("having_<agg>_<op> filters on aggregates", function()
+    local db = DB.connect()
+
+    local query = db.orders:find()
+        :group_by(db.orders.user_id)
+        :agg({
+            total = DB.sum(db.orders.amount),
+            order_count = DB.count(db.orders.id)
+        })
+        :having_order_count_bigger_than(5)
+
+    assert_equals(1, #query._having_filters)
+    assert_equals("order_count", query._having_filters[1].aggregate)
+    assert_equals("bigger_than", query._having_filters[1].operator)
+    assert_equals(5, query._having_filters[1].value)
+end)
+
+test("Aggregate functions create AggregateExpr", function()
+    local db = DB.connect()
+
+    local sum_expr = DB.sum(db.orders.amount)
+    assert_equals("aggregate", sum_expr._type)
+    assert_equals("SUM", sum_expr._func)
+
+    local count_expr = DB.count(db.orders.id)
+    assert_equals("COUNT", count_expr._func)
+
+    local avg_expr = DB.avg(db.orders.amount)
+    assert_equals("AVG", avg_expr._func)
+
+    local min_expr = DB.min(db.orders.amount)
+    assert_equals("MIN", min_expr._func)
+
+    local max_expr = DB.max(db.orders.amount)
+    assert_equals("MAX", max_expr._func)
+end)
+
+-- ============================================================================
+-- Phase 6: Ordering, Limit, Offset Tests
+-- ============================================================================
+
+print("\n--- Phase 6: Ordering, Limit, Offset Tests ---\n")
+
+test("order_by() adds ordering", function()
+    local db = DB.connect()
+
+    local query = db.users:find():order_by(db.users.created_at, "DESC")
+
+    assert_equals(1, #query._order_by)
+    assert_equals("DESC", query._order_by[1].direction)
+end)
+
+test("limit() adds limit", function()
+    local db = DB.connect()
+
+    local query = db.users:find():limit(10)
+
+    assert_equals(10, query._limit_val)
+end)
+
+test("offset() adds offset", function()
+    local db = DB.connect()
+
+    local query = db.users:find():offset(20)
+
+    assert_equals(20, query._offset_val)
+end)
+
+-- ============================================================================
+-- Phase 7: Preloads (with_*) Tests
+-- ============================================================================
+
+print("\n--- Phase 7: Preloads Tests ---\n")
+
+test("with_<relation>() adds preload", function()
+    local db = DB.connect()
+
+    local query = db.posts:find()
+        :by_published(true)
+        :with_user()
+        :with_comments()
+
+    assert_equals(2, #query._preloads)
+    assert_equals("user", query._preloads[1])
+    assert_equals("comments", query._preloads[2])
+end)
+
+-- ============================================================================
+-- Phase 8: SQL Generation Tests
+-- ============================================================================
+
+print("\n--- Phase 8: SQL Generation Tests ---\n")
+
+test("Basic SELECT generation", function()
+    local db = DB.connect()
+    local query = db.users:find()
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "SELECT *")
+    assert_contains(sql, "FROM users")
+end)
+
+test("SELECT with equals filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_status("active")
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "WHERE status = 'active'")
+end)
+
+test("SELECT with bigger_than filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_age_bigger_than(18)
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "WHERE age > 18")
+end)
+
+test("SELECT with contains filter (LIKE)", function()
+    local db = DB.connect()
+    local query = db.users:find():by_name_contains("ana")
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "LIKE '%ana%'")
+end)
+
+test("SELECT with starts_with filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_email_starts_with("admin")
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "LIKE 'admin%'")
+end)
+
+test("SELECT with in_list filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_status_in_list({"active", "pending"})
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "status IN")
+    assert_contains(sql, "'active'")
+    assert_contains(sql, "'pending'")
+end)
+
+test("SELECT with between filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_age_between({18, 65})
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "BETWEEN 18 AND 65")
+end)
+
+test("SELECT with is_null filter", function()
+    local db = DB.connect()
+    local query = db.users:find():by_deleted_at_is_null()
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "deleted_at IS NULL")
+end)
+
+test("SELECT with ORDER BY", function()
+    local db = DB.connect()
+    local query = db.users:find():order_by(db.users.created_at, "DESC")
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "ORDER BY users.created_at DESC")
+end)
+
+test("SELECT with LIMIT and OFFSET", function()
+    local db = DB.connect()
+    local query = db.users:find():limit(10):offset(20)
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "LIMIT 10")
+    assert_contains(sql, "OFFSET 20")
+end)
+
+test("SELECT with GROUP BY and aggregates", function()
+    local db = DB.connect()
+    local query = db.orders:find()
+        :group_by(db.orders.user_id)
+        :agg({
+            total = DB.sum(db.orders.amount),
+            order_count = DB.count(db.orders.id)
+        })
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "GROUP BY orders.user_id")
+    assert_contains(sql, "SUM(orders.amount)")
+    assert_contains(sql, "COUNT(orders.id)")
+end)
+
+test("SELECT with HAVING", function()
+    local db = DB.connect()
+    local query = db.orders:find()
+        :group_by(db.orders.user_id)
+        :agg({
+            order_count = DB.count(db.orders.id)
+        })
+        :having_order_count_bigger_than(5)
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "HAVING order_count > 5")
+end)
+
+test("SELECT with EXISTS subquery", function()
+    local db = DB.connect()
+    local query = db.users:find()
+        :exists(db.orders:find():by_status("paid"))
+        :on(db.orders.user_id, db.users.id)
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "EXISTS")
+    assert_contains(sql, "orders.user_id = users.id")
+end)
+
+test("SELECT with OR via merge", function()
+    local db = DB.connect()
+    local admins = db.users:find():by_role("admin")
+    local mods = db.users:find():by_role("moderator")
+    local query = db.users:find():merge(admins, mods)
+    local sql = DB._generate_sql(query)
+
+    assert_contains(sql, "OR")
+    assert_contains(sql, "role = 'admin'")
+    assert_contains(sql, "role = 'moderator'")
+end)
+
+-- ============================================================================
+-- Phase 9: Update Query Tests
+-- ============================================================================
+
+print("\n--- Phase 9: Update Query Tests ---\n")
+
+test("update() creates UpdateQuery", function()
+    local db = DB.connect()
+    local query = db.users:update()
+
+    assert_equals("update_query", query._type)
+end)
+
+test("UpdateQuery with set() and filter", function()
+    local db = DB.connect()
+    local query = db.users:update()
+        :by_id(1)
+        :set({ status = "inactive" })
+
+    assert_equals(1, #query._filters)
+    assert_equals("inactive", query._set_values.status)
+end)
+
+test("UPDATE SQL generation", function()
+    local db = DB.connect()
+    local query = db.users:update()
+        :by_id(1)
+        :set({ status = "inactive", updated_at = "2024-01-15" })
+    local sql = DB._generate_update_sql(query)
+
+    assert_contains(sql, "UPDATE users")
+    assert_contains(sql, "SET")
+    assert_contains(sql, "status = 'inactive'")
+    assert_contains(sql, "WHERE id = 1")
+end)
+
+-- ============================================================================
+-- Phase 10: Delete Query Tests
+-- ============================================================================
+
+print("\n--- Phase 10: Delete Query Tests ---\n")
+
+test("delete() creates DeleteQuery", function()
+    local db = DB.connect()
+    local query = db.users:delete()
+
+    assert_equals("delete_query", query._type)
+end)
+
+test("DeleteQuery with filter", function()
+    local db = DB.connect()
+    local query = db.users:delete():by_status("banned")
+
+    assert_equals(1, #query._filters)
+    assert_equals("status", query._filters[1].field)
+end)
+
+test("DELETE SQL generation", function()
+    local db = DB.connect()
+    local query = db.users:delete():by_status("banned")
+    local sql = DB._generate_delete_sql(query)
+
+    assert_contains(sql, "DELETE FROM users")
+    assert_contains(sql, "WHERE status = 'banned'")
+end)
+
+-- ============================================================================
+-- Phase 11: Insert SQL Generation Tests
+-- ============================================================================
+
+print("\n--- Phase 11: Insert SQL Generation Tests ---\n")
+
+test("INSERT SQL generation", function()
+    local sql = DB._generate_insert_sql("users", {
+        name = "Alice",
+        age = 30,
+        active = true
+    })
+
+    assert_contains(sql, "INSERT INTO users")
+    assert_contains(sql, "VALUES")
+    assert_contains(sql, "'Alice'")
+end)
+
+-- ============================================================================
+-- Phase 12: Raw SQL (Escape Hatch) Tests
+-- ============================================================================
+
+print("\n--- Phase 12: Raw SQL Tests ---\n")
+
+test("sql() creates RawQuery", function()
+    local db = DB.connect()
+    local query = db.users:sql()
+
+    assert_equals("raw_query", query._type)
+end)
+
+test("RawQuery with raw()", function()
+    local db = DB.connect()
+    local query = db.users:sql():raw("SELECT * FROM users WHERE age > 18")
+
+    assert_equals("SELECT * FROM users WHERE age > 18", query._sql)
+end)
+
+test("RawQuery inspect()", function()
+    local db = DB.connect()
+    local query = db.users:sql():raw("SELECT * FROM users WHERE age > ?", {18})
+    local info = query:inspect()
+
+    assert_equals("RAW SQL", info.intent)
+    assert_contains(info.sql, "SELECT * FROM users")
+end)
+
+-- ============================================================================
+-- Phase 13: inspect() Tests
+-- ============================================================================
+
+print("\n--- Phase 13: inspect() Tests ---\n")
+
+test("inspect() returns query info", function()
+    local db = DB.connect()
+    local query = db.users:find()
+        :by_status("active")
+        :by_age_bigger_than(18)
+        :limit(10)
+    local info = query:inspect()
+
+    assert_equals("SELECT", info.intent)
+    assert_equals("users", info.table)
+    assert_equals(2, #info.filters)
+    assert_equals(10, info.limit)
+    assert_not_nil(info.candidate_sql)
+end)
+
+test("inspect() shows EXISTS clauses", function()
+    local db = DB.connect()
+    local query = db.users:find()
+        :exists(db.orders:find():by_status("paid"))
+        :on(db.orders.user_id, db.users.id)
+    local info = query:inspect()
+
+    assert_equals(1, #info.exists_clauses)
+end)
+
+test("inspect() shows lowering strategy", function()
+    local db = DB.connect()
+    local query = db.users:find()
+        :exists(db.orders:find():by_status("paid"))
+        :on(db.orders.user_id, db.users.id)
+    local info = query:inspect()
+
+    assert_not_nil(info.lowering_strategy)
+    assert_true(#info.lowering_strategy > 0)
+end)
+
+-- ============================================================================
+-- Summary
+-- ============================================================================
+
+print("\n========================================")
+print("Test Results: " .. tests_passed .. " passed, " .. tests_failed .. " failed")
+print("========================================")
+
+if tests_failed > 0 then
+    os.exit(1)
+end
+
+return { passed = tests_passed, failed = tests_failed }

--- a/rover-db/tests/integration_test.rs
+++ b/rover-db/tests/integration_test.rs
@@ -1,0 +1,400 @@
+//! Integration tests for rover-db
+//!
+//! These tests verify the complete Lua DSL works end-to-end with actual database operations.
+
+use mlua::prelude::*;
+use rover_db::create_db_module;
+
+fn setup_lua() -> Lua {
+    let lua = Lua::new();
+
+    // Create rover.db module
+    let rover = lua.create_table().unwrap();
+    let db_module = create_db_module(&lua).unwrap();
+    rover.set("db", db_module).unwrap();
+    lua.globals().set("rover", rover).unwrap();
+
+    lua
+}
+
+#[test]
+fn test_connect_and_insert() {
+    let lua = setup_lua();
+
+    let result: LuaResult<LuaTable> = lua.load(r#"
+        local db = rover.db.connect()
+        local result = db.users:insert({
+            name = "Alice",
+            age = 30
+        })
+        return result
+    "#).eval();
+
+    assert!(result.is_ok(), "Insert should succeed");
+    let table = result.unwrap();
+    assert!(table.get::<bool>("success").unwrap());
+    assert!(table.get::<i64>("id").unwrap() >= 1);
+}
+
+#[test]
+fn test_find_and_filters() {
+    let lua = setup_lua();
+
+    let sql: String = lua.load(r#"
+        local db = rover.db.connect()
+
+        -- Build a query
+        local query = db.users:find()
+            :by_status("active")
+            :by_age_bigger_than(18)
+
+        -- Get the generated SQL via inspect
+        return query:inspect().candidate_sql
+    "#).eval().unwrap();
+
+    assert!(sql.contains("SELECT *"));
+    assert!(sql.contains("FROM users"));
+    assert!(sql.contains("status = 'active'"));
+    assert!(sql.contains("age > 18"));
+}
+
+#[test]
+fn test_contains_filter() {
+    let lua = setup_lua();
+
+    let sql: String = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.users:find():by_name_contains("ana")
+        return query:inspect().candidate_sql
+    "#).eval().unwrap();
+
+    assert!(sql.contains("LIKE '%ana%'"));
+}
+
+#[test]
+fn test_in_list_filter() {
+    let lua = setup_lua();
+
+    let sql: String = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.users:find():by_status_in_list({"active", "pending", "paid"})
+        return query:inspect().candidate_sql
+    "#).eval().unwrap();
+
+    assert!(sql.contains("status IN"));
+    assert!(sql.contains("'active'"));
+    assert!(sql.contains("'pending'"));
+    assert!(sql.contains("'paid'"));
+}
+
+#[test]
+fn test_between_filter() {
+    let lua = setup_lua();
+
+    let sql: String = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.users:find():by_age_between({18, 65})
+        return query:inspect().candidate_sql
+    "#).eval().unwrap();
+
+    assert!(sql.contains("BETWEEN 18 AND 65"));
+}
+
+#[test]
+fn test_is_null_filter() {
+    let lua = setup_lua();
+
+    let sql: String = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.users:find():by_deleted_at_is_null()
+        return query:inspect().candidate_sql
+    "#).eval().unwrap();
+
+    assert!(sql.contains("deleted_at IS NULL"));
+}
+
+#[test]
+fn test_exists_subquery() {
+    let lua = setup_lua();
+
+    let sql: String = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.users:find()
+            :exists(db.orders:find():by_status("paid"))
+            :on(db.orders.user_id, db.users.id)
+        return query:inspect().candidate_sql
+    "#).eval().unwrap();
+
+    assert!(sql.contains("EXISTS"));
+    assert!(sql.contains("orders.user_id = users.id"));
+    assert!(sql.contains("status = 'paid'"));
+}
+
+#[test]
+fn test_or_composition_merge() {
+    let lua = setup_lua();
+
+    let sql: String = lua.load(r#"
+        local db = rover.db.connect()
+        local admins = db.users:find():by_role("admin")
+        local mods = db.users:find():by_role("moderator")
+        local query = db.users:find():merge(admins, mods)
+        return query:inspect().candidate_sql
+    "#).eval().unwrap();
+
+    assert!(sql.contains("OR"));
+    assert!(sql.contains("role = 'admin'"));
+    assert!(sql.contains("role = 'moderator'"));
+}
+
+#[test]
+fn test_group_by_and_aggregates() {
+    let lua = setup_lua();
+
+    let sql: String = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.orders:find()
+            :group_by(db.orders.user_id)
+            :agg({
+                total = rover.db.sum(db.orders.amount),
+                order_count = rover.db.count(db.orders.id)
+            })
+        return query:inspect().candidate_sql
+    "#).eval().unwrap();
+
+    assert!(sql.contains("GROUP BY orders.user_id"));
+    assert!(sql.contains("SUM(orders.amount)"));
+    assert!(sql.contains("COUNT(orders.id)"));
+}
+
+#[test]
+fn test_having_clause() {
+    let lua = setup_lua();
+
+    let sql: String = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.orders:find()
+            :group_by(db.orders.user_id)
+            :agg({
+                order_count = rover.db.count(db.orders.id)
+            })
+            :having_order_count_bigger_than(5)
+        return query:inspect().candidate_sql
+    "#).eval().unwrap();
+
+    assert!(sql.contains("HAVING order_count > 5"));
+}
+
+#[test]
+fn test_order_by_limit_offset() {
+    let lua = setup_lua();
+
+    let sql: String = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.users:find()
+            :order_by(db.users.created_at, "DESC")
+            :limit(10)
+            :offset(20)
+        return query:inspect().candidate_sql
+    "#).eval().unwrap();
+
+    assert!(sql.contains("ORDER BY users.created_at DESC"));
+    assert!(sql.contains("LIMIT 10"));
+    assert!(sql.contains("OFFSET 20"));
+}
+
+#[test]
+fn test_update_query() {
+    let lua = setup_lua();
+
+    // Just verify the DSL works (can't easily test SQL generation for update without exposing it)
+    let result: LuaResult<LuaTable> = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.users:update()
+            :by_id(1)
+            :set({ status = "inactive" })
+
+        return {
+            type = query._type,
+            filter_count = #query._filters,
+            has_set_values = query._set_values.status ~= nil
+        }
+    "#).eval();
+
+    assert!(result.is_ok());
+    let table = result.unwrap();
+    assert_eq!(table.get::<String>("type").unwrap(), "update_query");
+    assert_eq!(table.get::<i64>("filter_count").unwrap(), 1);
+    assert!(table.get::<bool>("has_set_values").unwrap());
+}
+
+#[test]
+fn test_delete_query() {
+    let lua = setup_lua();
+
+    let result: LuaResult<LuaTable> = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.users:delete():by_status("banned")
+
+        return {
+            type = query._type,
+            filter_count = #query._filters
+        }
+    "#).eval();
+
+    assert!(result.is_ok());
+    let table = result.unwrap();
+    assert_eq!(table.get::<String>("type").unwrap(), "delete_query");
+    assert_eq!(table.get::<i64>("filter_count").unwrap(), 1);
+}
+
+#[test]
+fn test_raw_sql_escape_hatch() {
+    let lua = setup_lua();
+
+    let info: LuaTable = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.users:sql():raw("SELECT * FROM users WHERE age > 18")
+        return query:inspect()
+    "#).eval().unwrap();
+
+    assert_eq!(info.get::<String>("intent").unwrap(), "RAW SQL");
+    assert!(info.get::<String>("sql").unwrap().contains("SELECT * FROM users"));
+}
+
+#[test]
+fn test_preloads() {
+    let lua = setup_lua();
+
+    let preloads: LuaTable = lua.load(r#"
+        local db = rover.db.connect()
+        local query = db.posts:find()
+            :by_published(true)
+            :with_author()
+            :with_comments()
+        return query:inspect().preloads
+    "#).eval().unwrap();
+
+    assert_eq!(preloads.len().unwrap(), 2);
+    assert_eq!(preloads.get::<String>(1).unwrap(), "author");
+    assert_eq!(preloads.get::<String>(2).unwrap(), "comments");
+}
+
+#[test]
+fn test_query_immutability() {
+    let lua = setup_lua();
+
+    let result: LuaTable = lua.load(r#"
+        local db = rover.db.connect()
+        local query1 = db.users:find()
+        local query2 = query1:by_age(25)
+        local query3 = query1:by_status("active")
+
+        return {
+            q1_filters = #query1._filters,
+            q2_filters = #query2._filters,
+            q3_filters = #query3._filters
+        }
+    "#).eval().unwrap();
+
+    // Query1 should remain unchanged
+    assert_eq!(result.get::<i64>("q1_filters").unwrap(), 0);
+    // Query2 and Query3 should each have 1 filter
+    assert_eq!(result.get::<i64>("q2_filters").unwrap(), 1);
+    assert_eq!(result.get::<i64>("q3_filters").unwrap(), 1);
+}
+
+#[test]
+fn test_column_ref_tostring() {
+    let lua = setup_lua();
+
+    let col_str: String = lua.load(r#"
+        local db = rover.db.connect()
+        return tostring(db.users.id)
+    "#).eval().unwrap();
+
+    assert_eq!(col_str, "users.id");
+}
+
+#[test]
+fn test_aggregate_functions() {
+    let lua = setup_lua();
+
+    let result: LuaTable = lua.load(r#"
+        local db = rover.db.connect()
+        return {
+            sum_type = rover.db.sum(db.orders.amount)._type,
+            sum_func = rover.db.sum(db.orders.amount)._func,
+            count_func = rover.db.count(db.orders.id)._func,
+            avg_func = rover.db.avg(db.orders.amount)._func,
+            min_func = rover.db.min(db.orders.amount)._func,
+            max_func = rover.db.max(db.orders.amount)._func
+        }
+    "#).eval().unwrap();
+
+    assert_eq!(result.get::<String>("sum_type").unwrap(), "aggregate");
+    assert_eq!(result.get::<String>("sum_func").unwrap(), "SUM");
+    assert_eq!(result.get::<String>("count_func").unwrap(), "COUNT");
+    assert_eq!(result.get::<String>("avg_func").unwrap(), "AVG");
+    assert_eq!(result.get::<String>("min_func").unwrap(), "MIN");
+    assert_eq!(result.get::<String>("max_func").unwrap(), "MAX");
+}
+
+#[test]
+fn test_inspect_lowering_strategy() {
+    let lua = setup_lua();
+
+    let strategies: LuaTable = lua.load(r#"
+        local db = rover.db.connect()
+
+        -- Query with EXISTS
+        local q1 = db.users:find()
+            :exists(db.orders:find():by_status("paid"))
+            :on(db.orders.user_id, db.users.id)
+
+        return q1:inspect().lowering_strategy
+    "#).eval().unwrap();
+
+    let first_strategy: String = strategies.get(1).unwrap();
+    assert!(first_strategy.contains("EXISTS"));
+}
+
+#[test]
+fn test_insert_and_query_roundtrip() {
+    let lua = setup_lua();
+
+    let count: i64 = lua.load(r#"
+        local db = rover.db.connect()
+
+        -- Insert test data
+        db.test_users:insert({ name = "Test1", score = 100 })
+        db.test_users:insert({ name = "Test2", score = 200 })
+        db.test_users:insert({ name = "Test3", score = 150 })
+
+        -- Query and count
+        local results = db.test_users:find():by_score_bigger_than(120):all()
+        return #results
+    "#).eval().unwrap();
+
+    assert_eq!(count, 2); // Test2 (200) and Test3 (150)
+}
+
+#[test]
+fn test_first_returns_single_record() {
+    let lua = setup_lua();
+
+    let result: LuaTable = lua.load(r#"
+        local db = rover.db.connect()
+
+        -- Insert test data
+        db.first_test:insert({ name = "First", value = 1 })
+        db.first_test:insert({ name = "Second", value = 2 })
+
+        -- Get first record
+        local first = db.first_test:find():order_by(db.first_test.value, "ASC"):first()
+        return first
+    "#).eval().unwrap();
+
+    assert_eq!(result.get::<String>("name").unwrap(), "First");
+    assert_eq!(result.get::<i64>("value").unwrap(), 1);
+}

--- a/rover-db/tests/migration_test.rs
+++ b/rover-db/tests/migration_test.rs
@@ -1,0 +1,175 @@
+use rover_db::{Connection, MigrationExecutor, rollback_migrations, run_pending_migrations};
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[test]
+fn test_migration_execution() {
+    // Create in-memory database
+    let db_path = ":memory:";
+    let conn = Connection::new(db_path).expect("Failed to create connection");
+    let conn = Arc::new(Mutex::new(conn));
+
+    let executor = MigrationExecutor::new(conn.clone());
+
+    // Ensure migrations table exists
+    executor
+        .ensure_migrations_table()
+        .expect("Failed to create migrations table");
+
+    // Create unique migrations directory for this test
+    let migrations_dir = Path::new("tests/migrations_test_exec");
+    let _ = std::fs::remove_dir_all(migrations_dir);
+    std::fs::create_dir_all(migrations_dir).expect("Failed to create migrations dir");
+
+    // Create a simple migration
+    let migration_content = r#"
+migration.users:create({
+    name = rover.guard:string():required(),
+    email = rover.guard:string(),
+})
+"#;
+
+    let migration_file = migrations_dir.join("001_create_users.lua");
+    std::fs::write(&migration_file, migration_content).expect("Failed to write migration file");
+
+    // Run migrations
+    let result = run_pending_migrations(&executor, migrations_dir);
+    assert!(result.is_ok(), "Migration should succeed: {:?}", result);
+    let count = result.unwrap();
+    assert_eq!(count, 1, "Should run 1 migration");
+
+    // Check migration status
+    let status = executor
+        .get_status(migrations_dir)
+        .expect("Failed to get status");
+    assert!(status.applied.contains("001_create_users"));
+    assert!(status.pending.is_empty());
+
+    // Verify table exists
+    let conn_lock = conn.blocking_lock();
+    let schema = conn_lock
+        .get_table_schema("users")
+        .expect("Failed to get table schema");
+    assert_eq!(schema.len(), 3, "Should have 3 columns (id + name + email)");
+
+    // Cleanup
+    let _ = std::fs::remove_file(&migration_file);
+    // Only remove directory if it's empty
+    if std::fs::read_dir(migrations_dir)
+        .map(|mut e| e.next().is_none())
+        .unwrap_or(false)
+    {
+        let _ = std::fs::remove_dir(migrations_dir);
+    }
+}
+
+#[test]
+fn test_rollback_migration() {
+    // Create in-memory database
+    let db_path = ":memory:";
+    let conn = Connection::new(db_path).expect("Failed to create connection");
+    let conn = Arc::new(Mutex::new(conn));
+
+    let executor = MigrationExecutor::new(conn.clone());
+
+    // Ensure migrations table exists
+    executor
+        .ensure_migrations_table()
+        .expect("Failed to create migrations table");
+
+    // Create unique migrations directory for this test
+    let migrations_dir = Path::new("tests/migrations_test_rollback");
+    let _ = std::fs::remove_dir_all(migrations_dir);
+    std::fs::create_dir_all(migrations_dir).expect("Failed to create migrations dir");
+
+    // Create a simple migration
+    let migration_content = r#"
+migration.users:create({
+    name = rover.guard:string():required(),
+})
+"#;
+
+    let migration_file = migrations_dir.join("002_rollback_test.lua");
+    std::fs::write(&migration_file, migration_content).expect("Failed to write migration file");
+
+    // Run migration first
+    run_pending_migrations(&executor, migrations_dir).expect("Migration should succeed");
+
+    // Verify table exists
+    let conn_lock = conn.blocking_lock();
+    let schema = conn_lock
+        .get_table_schema("users")
+        .expect("Failed to get table schema");
+    assert_eq!(schema.len(), 2, "Should have 2 columns");
+    drop(conn_lock);
+
+    // Rollback
+    let result = rollback_migrations(&executor, migrations_dir, 1);
+    assert!(result.is_ok(), "Rollback should succeed: {:?}", result);
+    let count = result.unwrap();
+    assert_eq!(count, 1, "Should rollback 1 migration");
+
+    // Verify table is dropped
+    let status = executor
+        .get_status(migrations_dir)
+        .expect("Failed to get status");
+    assert!(status.applied.is_empty());
+
+    // Cleanup
+    let _ = std::fs::remove_file(&migration_file);
+    if std::fs::read_dir(migrations_dir)
+        .map(|mut e| e.next().is_none())
+        .unwrap_or(false)
+    {
+        let _ = std::fs::remove_dir(migrations_dir);
+    }
+}
+
+#[test]
+fn test_migration_status() {
+    let db_path = ":memory:";
+    let conn = Connection::new(db_path).expect("Failed to create connection");
+    let conn = Arc::new(Mutex::new(conn));
+
+    let executor = MigrationExecutor::new(conn.clone());
+
+    executor
+        .ensure_migrations_table()
+        .expect("Failed to create migrations table");
+
+    // Create unique migrations directory for this test
+    let migrations_dir = Path::new("tests/migrations_test_status");
+    let _ = std::fs::remove_dir_all(migrations_dir);
+    std::fs::create_dir_all(migrations_dir).expect("Failed to create migrations dir");
+
+    // Create multiple migrations
+    let migration1 = r#"migration.posts:create({title = rover.guard:string()})"#;
+    let migration2 = r#"migration.comments:create({body = rover.guard:string()})"#;
+
+    std::fs::write(migrations_dir.join("003_posts.lua"), migration1).unwrap();
+    std::fs::write(migrations_dir.join("004_comments.lua"), migration2).unwrap();
+
+    // Check status - all pending
+    let status = executor.get_status(migrations_dir).unwrap();
+    assert_eq!(status.available.len(), 2);
+    assert_eq!(status.pending.len(), 2);
+    assert!(status.applied.is_empty());
+
+    // Run all pending migrations
+    let count = run_pending_migrations(&executor, migrations_dir).unwrap();
+    assert_eq!(count, 2, "Should run 2 migrations");
+
+    // Check status - all applied, none pending
+    let status = executor.get_status(migrations_dir).unwrap();
+    assert_eq!(status.available.len(), 2);
+    assert_eq!(status.pending.len(), 0);
+    assert_eq!(status.applied.len(), 2, "Should have 2 applied migrations");
+
+    // Cleanup
+    std::fs::remove_file(migrations_dir.join("003_posts.lua")).ok();
+    std::fs::remove_file(migrations_dir.join("004_comments.lua")).ok();
+    if migrations_dir.exists() && std::fs::read_dir(migrations_dir).unwrap().next().is_none() {
+        std::fs::remove_dir(migrations_dir).ok();
+    }
+}

--- a/rover-db/tests/migrations/001_create_users.lua
+++ b/rover-db/tests/migrations/001_create_users.lua
@@ -1,0 +1,5 @@
+
+migration.users:create({
+    name = rover.guard:string():required(),
+    email = rover.guard:string(),
+})

--- a/rover-db/tests/migrations/002_rollback_test.lua
+++ b/rover-db/tests/migrations/002_rollback_test.lua
@@ -1,0 +1,4 @@
+
+migration.users:create({
+    name = rover.guard:string():required(),
+})

--- a/rover-db/tests/migrations/003_posts.lua
+++ b/rover-db/tests/migrations/003_posts.lua
@@ -1,0 +1,1 @@
+migration.posts:create({title = rover.guard:string()})

--- a/rover-db/tests/migrations/004_comments.lua
+++ b/rover-db/tests/migrations/004_comments.lua
@@ -1,0 +1,1 @@
+migration.comments:create({body = rover.guard:string()})

--- a/rover-parser/src/db_intent.rs
+++ b/rover-parser/src/db_intent.rs
@@ -1,0 +1,527 @@
+//! Database Intent Analysis
+//!
+//! Analyzes Lua AST to extract database intent - what tables, fields, and types
+//! the code expects to use. Uses the same tree-sitter infrastructure as the main analyzer.
+
+use std::collections::HashMap;
+use tree_sitter::Node;
+
+/// Inferred field type from AST analysis
+#[derive(Debug, Clone, PartialEq)]
+pub enum FieldType {
+    Integer,
+    Number,
+    String,
+    Boolean,
+    Unknown,
+}
+
+impl FieldType {
+    /// Convert to guard DSL type name
+    pub fn to_guard_type(&self) -> &'static str {
+        match self {
+            FieldType::Integer => "integer",
+            FieldType::Number => "number",
+            FieldType::String => "string",
+            FieldType::Boolean => "boolean",
+            FieldType::Unknown => "string",
+        }
+    }
+
+    /// Infer type from AST node kind
+    pub fn from_ast_kind(kind: &str) -> Self {
+        match kind {
+            "string" => FieldType::String,
+            "number" => FieldType::Number, // Will refine to Integer if whole number
+            "true" | "false" => FieldType::Boolean,
+            _ => FieldType::Unknown,
+        }
+    }
+
+    /// Refine number type based on literal value
+    pub fn refine_number(value: &str) -> Self {
+        if value.contains('.') {
+            FieldType::Number
+        } else {
+            FieldType::Integer
+        }
+    }
+}
+
+/// Source of where a field was inferred from
+#[derive(Debug, Clone)]
+pub enum FieldSource {
+    /// From insert: { field = value }
+    Insert { value_hint: String },
+    /// From filter: :by_field(value)
+    Filter { method: String },
+    /// From field access: db.table.field
+    Access,
+    /// Auto-generated (like id)
+    Auto,
+}
+
+impl std::fmt::Display for FieldSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FieldSource::Insert { value_hint } => write!(f, "from insert: {{ {} }}", value_hint),
+            FieldSource::Filter { method } => write!(f, "from :{}()", method),
+            FieldSource::Access => write!(f, "from field access"),
+            FieldSource::Auto => write!(f, "auto-generated"),
+        }
+    }
+}
+
+/// An inferred field
+#[derive(Debug, Clone)]
+pub struct InferredField {
+    pub name: String,
+    pub field_type: FieldType,
+    pub source: FieldSource,
+}
+
+/// An inferred table with its fields
+#[derive(Debug, Clone)]
+pub struct InferredTable {
+    pub name: String,
+    pub fields: HashMap<String, InferredField>,
+}
+
+impl InferredTable {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            fields: HashMap::new(),
+        }
+    }
+
+    /// Add field, keeping the more specific type if field exists
+    pub fn add_field(&mut self, field: InferredField) {
+        let name = field.name.clone();
+        if let Some(existing) = self.fields.get(&name) {
+            // Keep more specific type
+            if existing.field_type == FieldType::Unknown && field.field_type != FieldType::Unknown {
+                self.fields.insert(name, field);
+            }
+        } else {
+            self.fields.insert(name, field);
+        }
+    }
+
+    pub fn ensure_id_field(&mut self) {
+        self.fields.insert(
+            "id".to_string(),
+            InferredField {
+                name: "id".to_string(),
+                field_type: FieldType::Integer,
+                source: FieldSource::Auto,
+            },
+        );
+    }
+}
+
+/// Database intent extracted from code
+#[derive(Debug, Clone, Default)]
+pub struct DbIntent {
+    pub tables: HashMap<String, InferredTable>,
+}
+
+impl DbIntent {
+    pub fn new() -> Self {
+        Self {
+            tables: HashMap::new(),
+        }
+    }
+
+    pub fn get_or_create_table(&mut self, name: &str) -> &mut InferredTable {
+        if !self.tables.contains_key(name) {
+            self.tables.insert(name.to_string(), InferredTable::new(name));
+        }
+        self.tables.get_mut(name).unwrap()
+    }
+
+    pub fn table_names(&self) -> Vec<String> {
+        self.tables.keys().cloned().collect()
+    }
+
+    /// Finalize intent - add auto id fields to all tables
+    pub fn finalize(&mut self) {
+        for table in self.tables.values_mut() {
+            table.ensure_id_field();
+        }
+    }
+}
+
+/// Intent analyzer that walks the AST
+pub struct IntentAnalyzer<'a> {
+    source: &'a str,
+    pub intent: DbIntent,
+}
+
+impl<'a> IntentAnalyzer<'a> {
+    pub fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            intent: DbIntent::new(),
+        }
+    }
+
+    /// Walk AST node and extract database intent
+    pub fn walk(&mut self, node: Node<'a>) {
+        match node.kind() {
+            "function_call" => self.analyze_function_call(node),
+            "dot_index_expression" => self.analyze_dot_access(node),
+            _ => {}
+        }
+
+        // Recurse into children
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk(child);
+        }
+    }
+
+    /// Analyze a function call for db operations
+    fn analyze_function_call(&mut self, node: Node<'a>) {
+        // Look for method_index_expression child (db.table:method())
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "method_index_expression" {
+                if let Some((object_path, method)) = self.extract_method_info(child) {
+                    if let Some(table_name) = self.extract_table_from_path(&object_path) {
+                        self.handle_db_method(&table_name, &method, node);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handle a db method call
+    fn handle_db_method(&mut self, table_name: &str, method: &str, call_node: Node<'a>) {
+        match method {
+            "insert" => {
+                // Extract fields from table constructor argument
+                if let Some(args_node) = self.find_arguments(call_node) {
+                    self.extract_insert_fields(table_name, args_node);
+                }
+            }
+            _ if method.starts_with("by_") => {
+                let raw_field = method.strip_prefix("by_").unwrap();
+                if let Some(field_name) = extract_field_from_filter(raw_field) {
+                    let field_type = if let Some(args_node) = self.find_arguments(call_node) {
+                        self.infer_type_from_argument(args_node)
+                    } else {
+                        FieldType::Unknown
+                    };
+
+                    let table = self.intent.get_or_create_table(table_name);
+                    table.add_field(InferredField {
+                        name: field_name.to_string(),
+                        field_type,
+                        source: FieldSource::Filter {
+                            method: method.to_string(),
+                        },
+                    });
+                }
+            }
+            _ => {
+                // Just ensure table is tracked
+                self.intent.get_or_create_table(table_name);
+            }
+        }
+    }
+
+    /// Extract fields from insert table constructor
+    fn extract_insert_fields(&mut self, table_name: &str, args_node: Node<'a>) {
+        // Find table_constructor in arguments
+        let mut cursor = args_node.walk();
+        for child in args_node.children(&mut cursor) {
+            if child.kind() == "table_constructor" {
+                self.extract_table_constructor_fields(table_name, child);
+            }
+        }
+    }
+
+    /// Extract fields from table constructor { field = value, ... }
+    fn extract_table_constructor_fields(&mut self, table_name: &str, node: Node<'a>) {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "field" {
+                self.extract_field(table_name, child);
+            }
+        }
+    }
+
+    /// Extract a single field from a field node
+    fn extract_field(&mut self, table_name: &str, node: Node<'a>) {
+        let mut field_name: Option<String> = None;
+        let mut field_type = FieldType::Unknown;
+        let mut value_hint = String::new();
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            match child.kind() {
+                "identifier" if field_name.is_none() => {
+                    field_name = Some(self.node_text(child).to_string());
+                }
+                "string" => {
+                    field_type = FieldType::String;
+                    value_hint = self.node_text(child).to_string();
+                }
+                "number" => {
+                    let text = self.node_text(child);
+                    field_type = FieldType::refine_number(text);
+                    value_hint = text.to_string();
+                }
+                "true" | "false" => {
+                    field_type = FieldType::Boolean;
+                    value_hint = self.node_text(child).to_string();
+                }
+                "identifier" if field_name.is_some() => {
+                    // Variable reference - can't determine type
+                    value_hint = self.node_text(child).to_string();
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(name) = field_name {
+            // Skip id field - it's auto-generated
+            if name == "id" {
+                return;
+            }
+
+            let table = self.intent.get_or_create_table(table_name);
+            table.add_field(InferredField {
+                name: name.clone(),
+                field_type,
+                source: FieldSource::Insert {
+                    value_hint: if value_hint.is_empty() {
+                        name
+                    } else {
+                        format!("{} = {}", name, value_hint)
+                    },
+                },
+            });
+        }
+    }
+
+    /// Analyze dot access for field references like db.table.field
+    fn analyze_dot_access(&mut self, node: Node<'a>) {
+        let path = self.extract_full_path(node);
+        let parts: Vec<&str> = path.split('.').collect();
+
+        // Need db.table.field (3+ parts)
+        if parts.len() >= 3 && parts[0] == "db" {
+            let table_name = parts[1];
+            let field_name = parts[2];
+
+            let table = self.intent.get_or_create_table(table_name);
+            table.add_field(InferredField {
+                name: field_name.to_string(),
+                field_type: FieldType::Unknown,
+                source: FieldSource::Access,
+            });
+        }
+    }
+
+    /// Extract method info from method_index_expression
+    fn extract_method_info(&self, node: Node<'a>) -> Option<(String, String)> {
+        let mut cursor = node.walk();
+        let children: Vec<_> = node.children(&mut cursor).collect();
+
+        // First named child is the object
+        let object = children.first()?;
+        let object_path = self.extract_full_path(*object);
+
+        // Last identifier is the method name
+        let method = children
+            .iter()
+            .rev()
+            .find(|c| c.kind() == "identifier")
+            .map(|c| self.node_text(*c).to_string())?;
+
+        Some((object_path, method))
+    }
+
+    /// Extract full dotted path from expression
+    fn extract_full_path(&self, node: Node<'a>) -> String {
+        let mut parts = Vec::new();
+        self.collect_path_parts(node, &mut parts);
+        parts.join(".")
+    }
+
+    fn collect_path_parts(&self, node: Node<'a>, parts: &mut Vec<String>) {
+        match node.kind() {
+            "identifier" => {
+                parts.push(self.node_text(node).to_string());
+            }
+            "dot_index_expression" => {
+                let mut cursor = node.walk();
+                let children: Vec<_> = node.children(&mut cursor).collect();
+
+                // Process base first
+                if let Some(base) = children.first() {
+                    self.collect_path_parts(*base, parts);
+                }
+
+                // Add field (last identifier)
+                for child in children.iter().rev() {
+                    if child.kind() == "identifier" {
+                        parts.push(self.node_text(*child).to_string());
+                        break;
+                    }
+                }
+            }
+            "function_call" => {
+                // For chained calls, look inside
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    if matches!(
+                        child.kind(),
+                        "method_index_expression" | "dot_index_expression" | "function_call"
+                    ) {
+                        self.collect_path_parts(child, parts);
+                        break;
+                    }
+                }
+            }
+            "method_index_expression" => {
+                // Get object part only (before colon)
+                if let Some(object) = node.named_child(0) {
+                    self.collect_path_parts(object, parts);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Extract table name from path like "db.users"
+    fn extract_table_from_path(&self, path: &str) -> Option<String> {
+        let parts: Vec<&str> = path.split('.').collect();
+        if parts.len() >= 2 && parts[0] == "db" {
+            Some(parts[1].to_string())
+        } else {
+            None
+        }
+    }
+
+    /// Find arguments node in function call
+    fn find_arguments(&self, call_node: Node<'a>) -> Option<Node<'a>> {
+        let mut cursor = call_node.walk();
+        for child in call_node.children(&mut cursor) {
+            if child.kind() == "arguments" {
+                return Some(child);
+            }
+        }
+        None
+    }
+
+    /// Infer type from first argument
+    fn infer_type_from_argument(&self, args_node: Node<'a>) -> FieldType {
+        if let Some(first_arg) = args_node.named_child(0) {
+            match first_arg.kind() {
+                "string" => FieldType::String,
+                "number" => FieldType::refine_number(self.node_text(first_arg)),
+                "true" | "false" => FieldType::Boolean,
+                _ => FieldType::Unknown,
+            }
+        } else {
+            FieldType::Unknown
+        }
+    }
+
+    /// Get text for a node
+    fn node_text(&self, node: Node) -> &str {
+        &self.source[node.start_byte()..node.end_byte()]
+    }
+}
+
+const FILTER_SUFFIXES: &[&str] = &[
+    "_ends_with", "_starts_with", "_contains", "_bigger_than", "_smaller_than",
+    "_between", "_in_list", "_not_in", "_is_null", "_is_not_null", "_like",
+];
+
+fn extract_field_from_filter(raw: &str) -> Option<String> {
+    for suffix in FILTER_SUFFIXES {
+        if raw.ends_with(suffix) {
+            let field = raw.strip_suffix(suffix)?;
+            if !field.is_empty() {
+                return Some(field.to_string());
+            }
+        }
+    }
+    Some(raw.to_string())
+}
+
+pub fn analyze_db_intent(source: &str) -> DbIntent {
+    let mut parser = tree_sitter::Parser::new();
+    let language = tree_sitter_lua::LANGUAGE;
+    parser
+        .set_language(&language.into())
+        .expect("Error loading Lua parser");
+
+    let Some(tree) = parser.parse(source, None) else {
+        return DbIntent::new();
+    };
+
+    let mut analyzer = IntentAnalyzer::new(source);
+    analyzer.walk(tree.root_node());
+    analyzer.intent.finalize();
+    analyzer.intent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_fields() {
+        let code = r#"db.users:insert({ name = "Alice", age = 30, active = true })"#;
+        let intent = analyze_db_intent(code);
+
+        let users = intent.tables.get("users").unwrap();
+        assert_eq!(users.fields.get("name").unwrap().field_type, FieldType::String);
+        assert_eq!(users.fields.get("age").unwrap().field_type, FieldType::Integer);
+        assert_eq!(users.fields.get("active").unwrap().field_type, FieldType::Boolean);
+    }
+
+    #[test]
+    fn test_filter_fields() {
+        let code = r#"db.users:find():by_status("active"):all()"#;
+        let intent = analyze_db_intent(code);
+
+        let users = intent.tables.get("users").unwrap();
+        assert!(users.fields.contains_key("status"));
+        assert_eq!(users.fields.get("status").unwrap().field_type, FieldType::String);
+    }
+
+    #[test]
+    fn test_field_access() {
+        let code = r#"local x = db.orders.user_id"#;
+        let intent = analyze_db_intent(code);
+
+        let orders = intent.tables.get("orders").unwrap();
+        assert!(orders.fields.contains_key("user_id"));
+    }
+
+    #[test]
+    fn test_auto_id() {
+        let code = r#"db.products:insert({ name = "Widget" })"#;
+        let intent = analyze_db_intent(code);
+
+        let products = intent.tables.get("products").unwrap();
+        assert!(products.fields.contains_key("id"));
+        assert_eq!(products.fields.get("id").unwrap().field_type, FieldType::Integer);
+    }
+
+    #[test]
+    fn test_number_vs_integer() {
+        let code = r#"db.orders:insert({ count = 5, amount = 99.99 })"#;
+        let intent = analyze_db_intent(code);
+
+        let orders = intent.tables.get("orders").unwrap();
+        assert_eq!(orders.fields.get("count").unwrap().field_type, FieldType::Integer);
+        assert_eq!(orders.fields.get("amount").unwrap().field_type, FieldType::Number);
+    }
+}

--- a/rover-parser/src/db_intent.rs
+++ b/rover-parser/src/db_intent.rs
@@ -135,7 +135,8 @@ impl DbIntent {
 
     pub fn get_or_create_table(&mut self, name: &str) -> &mut InferredTable {
         if !self.tables.contains_key(name) {
-            self.tables.insert(name.to_string(), InferredTable::new(name));
+            self.tables
+                .insert(name.to_string(), InferredTable::new(name));
         }
         self.tables.get_mut(name).unwrap()
     }
@@ -438,8 +439,17 @@ impl<'a> IntentAnalyzer<'a> {
 }
 
 const FILTER_SUFFIXES: &[&str] = &[
-    "_ends_with", "_starts_with", "_contains", "_bigger_than", "_smaller_than",
-    "_between", "_in_list", "_not_in", "_is_null", "_is_not_null", "_like",
+    "_ends_with",
+    "_starts_with",
+    "_contains",
+    "_bigger_than",
+    "_smaller_than",
+    "_between",
+    "_in_list",
+    "_not_in",
+    "_is_null",
+    "_is_not_null",
+    "_like",
 ];
 
 fn extract_field_from_filter(raw: &str) -> Option<String> {
@@ -481,9 +491,18 @@ mod tests {
         let intent = analyze_db_intent(code);
 
         let users = intent.tables.get("users").unwrap();
-        assert_eq!(users.fields.get("name").unwrap().field_type, FieldType::String);
-        assert_eq!(users.fields.get("age").unwrap().field_type, FieldType::Integer);
-        assert_eq!(users.fields.get("active").unwrap().field_type, FieldType::Boolean);
+        assert_eq!(
+            users.fields.get("name").unwrap().field_type,
+            FieldType::String
+        );
+        assert_eq!(
+            users.fields.get("age").unwrap().field_type,
+            FieldType::Integer
+        );
+        assert_eq!(
+            users.fields.get("active").unwrap().field_type,
+            FieldType::Boolean
+        );
     }
 
     #[test]
@@ -493,7 +512,10 @@ mod tests {
 
         let users = intent.tables.get("users").unwrap();
         assert!(users.fields.contains_key("status"));
-        assert_eq!(users.fields.get("status").unwrap().field_type, FieldType::String);
+        assert_eq!(
+            users.fields.get("status").unwrap().field_type,
+            FieldType::String
+        );
     }
 
     #[test]
@@ -512,7 +534,10 @@ mod tests {
 
         let products = intent.tables.get("products").unwrap();
         assert!(products.fields.contains_key("id"));
-        assert_eq!(products.fields.get("id").unwrap().field_type, FieldType::Integer);
+        assert_eq!(
+            products.fields.get("id").unwrap().field_type,
+            FieldType::Integer
+        );
     }
 
     #[test]
@@ -521,7 +546,13 @@ mod tests {
         let intent = analyze_db_intent(code);
 
         let orders = intent.tables.get("orders").unwrap();
-        assert_eq!(orders.fields.get("count").unwrap().field_type, FieldType::Integer);
-        assert_eq!(orders.fields.get("amount").unwrap().field_type, FieldType::Number);
+        assert_eq!(
+            orders.fields.get("count").unwrap().field_type,
+            FieldType::Integer
+        );
+        assert_eq!(
+            orders.fields.get("amount").unwrap().field_type,
+            FieldType::Number
+        );
     }
 }

--- a/rover-parser/src/lib.rs
+++ b/rover-parser/src/lib.rs
@@ -1,4 +1,5 @@
 mod analyzer;
+pub mod db_intent;
 mod formatter;
 mod incremental;
 mod specs;


### PR DESCRIPTION
This implements the rover-db module as specified in the design document,
providing an intent-based query system where code expresses what you want
and Rover decides how to execute it.

Key features:
- Dynamic table/column access via metatables (db.users, db.users.id)
- Query objects via :find() that are immutable and composable
- Semantic filters: by_<field>_<operator>(value)
  - equals, not_equals, bigger_than, smaller_than
  - contains, starts_with, ends_with
  - between, in_list, not_in_list
  - is_null, is_not_null
- Subqueries as first-class Query objects
- EXISTS with correlated subqueries via :exists():on()
- OR composition via :merge() (not boolean operators)
- Grouping & aggregates: :group_by(), :agg(), :having_*
- Query introspection via :inspect()
- Raw SQL escape hatch via :sql():raw()
- Schema inference from data for auto-migration
- SQLite/libsql backend with coroutine support

The module follows the core philosophy:
- SQL describes execution, ORMs describe structure
- rover-db describes INTENT