### PR TITLE
env-config: add rover.env access + optional config helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2167,7 @@ dependencies = [
  "bytes",
  "colored",
  "curl",
+ "dotenvy",
  "mlua",
  "rover-openapi",
  "rover-parser",

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,0 +1,20 @@
+# Example .env file for testing rover.env
+# Copy this to .env in the project root or set these vars in your shell
+
+# API Configuration
+API_KEY=example-secret-key-12345
+API_SECRET=another-secret-value
+
+# Database Configuration
+DATABASE_URL=postgres://user:pass@localhost:5432/mydb
+DB_HOST=localhost
+DB_PORT=5432
+
+# Application Settings
+DEBUG=true
+LOG_LEVEL=debug
+PORT=4242
+
+# Rover-specific vars
+ROVER_ENV=development
+ROVER_FEATURE_FLAGS=websocket,auth,caching

--- a/examples/env_config.lua
+++ b/examples/env_config.lua
@@ -1,0 +1,85 @@
+-- Environment and Config Example - Simple API
+-- Access env vars directly: rover.env.MY_VAR
+--
+-- Run with:
+--   API_KEY=secret123 DB_HOST=localhost cargo run -p rover_cli -- run examples/env_config.lua
+
+local api = rover.server {}
+
+-- Example 1: Direct env var access
+function api.env.get(ctx)
+  -- Access env vars directly as properties
+  local api_key = rover.env.API_KEY
+  local db_host = rover.env.DB_HOST or "localhost"
+  local db_port = rover.env.DB_PORT or "5432"
+
+  return api.json {
+    api_key = api_key,
+    database = {
+      host = db_host,
+      port = db_port,
+    },
+  }
+end
+
+-- Example 2: Check if env var is set
+function api.check.get(ctx)
+  if rover.env.DEBUG then
+    return api.json {
+      mode = "debug",
+      debug_enabled = true,
+    }
+  else
+    return api.json {
+      mode = "production",
+      debug_enabled = false,
+    }
+  end
+end
+
+-- Example 3: Load config from file
+function api.config.get(ctx)
+  local success, config = pcall(function()
+    return rover.config.load("examples/test_config.lua")
+  end)
+
+  if not success then
+    return api.json:status(404, {
+      error = "Config file not found",
+    })
+  end
+
+  return api.json {
+    config = config,
+  }
+end
+
+-- Example 4: Load config from env vars with prefix
+-- Note: Set these env vars before running, e.g.:
+--   export APP_DEBUG=true APP_API_KEY=secret123 APP_DB_HOST=db.example.com
+function api.config_env.get(ctx)
+  -- Load config from env vars with APP_ prefix
+  local config = rover.config.from_env("APP")
+
+  return api.json {
+    config = config,
+    note = "Set APP_DEBUG, APP_API_KEY, APP_DB_HOST env vars before running",
+  }
+end
+
+-- Example 5: Production config pattern
+function api.production.get(ctx)
+  -- Direct access with defaults using Lua's or operator
+  local config = {
+    port = tonumber(rover.env.PORT or "3000"),
+    host = rover.env.HOST or "0.0.0.0",
+    log_level = rover.env.LOG_LEVEL or "info",
+  }
+
+  return api.json {
+    config = config,
+    note = "Set PORT, HOST, LOG_LEVEL env vars or create a .env file",
+  }
+end
+
+return api

--- a/examples/test_config.lua
+++ b/examples/test_config.lua
@@ -1,0 +1,19 @@
+-- Test config file for rover.config.load() example
+return {
+  app_name = "Rover Demo",
+  version = "1.0.0",
+  features = {
+    "auth",
+    "database",
+    "websocket",
+  },
+  database = {
+    host = "localhost",
+    port = 5432,
+    name = "myapp",
+  },
+  settings = {
+    max_connections = 100,
+    timeout_seconds = 30,
+  },
+}

--- a/rover-core/Cargo.toml
+++ b/rover-core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 ahash = "0.8"
 anyhow = "1.0.100"
 bytes = "1.10"
+dotenvy = "0.15"
 mlua = { version="0.11.5", features = ["anyhow", "vendored", "luajit52", "serialize"] }
 rover_server = {path = "../rover-server"}
 rover-parser = {path = "../rover-parser"}

--- a/rover-core/src/env.rs
+++ b/rover-core/src/env.rs
@@ -1,0 +1,249 @@
+use anyhow::Result;
+use mlua::{Lua, Table, Value};
+use std::collections::HashMap;
+
+/// Load .env file from current directory
+pub fn load_dotenv() -> Result<HashMap<String, String>> {
+    let mut env_vars = HashMap::new();
+
+    // Try to load .env file from current directory
+    match dotenvy::dotenv() {
+        Ok(path) => {
+            tracing::debug!("Loaded .env file from: {:?}", path);
+        }
+        Err(e) => {
+            // It's ok if .env doesn't exist, just log it
+            tracing::debug!("No .env file found: {}", e);
+        }
+    }
+
+    // Collect all environment variables that were set (including from .env)
+    for (key, value) in std::env::vars() {
+        env_vars.insert(key, value);
+    }
+
+    Ok(env_vars)
+}
+
+/// Create the rover.env module for Lua
+/// Access env vars directly: rover.env.MY_VAR (read-only)
+pub fn create_env_module(lua: &Lua) -> Result<Table> {
+    // Create the env table
+    let env_module = lua.create_table()?;
+
+    // Add __index metamethod for direct env var access (read-only)
+    let meta = lua.create_table()?;
+    meta.set(
+        "__index",
+        lua.create_function(
+            |_lua, (_, key): (Table, String)| match std::env::var(&key) {
+                Ok(value) => Ok(Value::String(_lua.create_string(&value)?)),
+                Err(_) => Ok(Value::Nil),
+            },
+        )?,
+    )?;
+
+    // Add __newindex to make read-only (error on attempt to set)
+    meta.set(
+        "__newindex",
+        lua.create_function(|_, (_, key): (Table, String)| {
+            Err::<(), mlua::Error>(mlua::Error::RuntimeError(format!(
+                "rover.env is read-only - cannot set '{}'",
+                key
+            )))
+        })?,
+    )?;
+
+    env_module.set_metatable(Some(meta))?;
+
+    Ok(env_module)
+}
+
+/// Create the rover.config module for Lua
+pub fn create_config_module(lua: &Lua) -> Result<Table> {
+    let config_module = lua.create_table()?;
+
+    // rover.config.load(path) - Load a Lua config file and return as table
+    config_module.set(
+        "load",
+        lua.create_function(|lua, path: String| {
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(e) => {
+                    return Err(mlua::Error::RuntimeError(format!(
+                        "Failed to load config file '{}': {}",
+                        path, e
+                    )));
+                }
+            };
+
+            match lua.load(&content).set_name(&path).eval::<Value>() {
+                Ok(value) => Ok(value),
+                Err(e) => Err(mlua::Error::RuntimeError(format!(
+                    "Failed to parse config file '{}': {}",
+                    path, e
+                ))),
+            }
+        })?,
+    )?;
+
+    // rover.config.from_env(prefix) - Load config from env vars with prefix
+    config_module.set(
+        "from_env",
+        lua.create_function(|lua, prefix: String| {
+            let table = lua.create_table()?;
+            let prefix_upper = prefix.to_uppercase();
+
+            for (key, value) in std::env::vars() {
+                if key.starts_with(&prefix_upper) {
+                    // Remove prefix and convert to nested table structure
+                    let config_key = &key[prefix_upper.len()..];
+                    let config_key = config_key.trim_start_matches('_');
+
+                    // Split by underscore and create nested structure
+                    let parts: Vec<&str> = config_key.split('_').collect();
+                    if !parts.is_empty() {
+                        let mut current = table.clone();
+                        for (i, part) in parts.iter().enumerate() {
+                            let part_lower = part.to_lowercase();
+                            if i == parts.len() - 1 {
+                                // Last part - set the value
+                                current.set(part_lower, lua.create_string(&value)?)?;
+                            } else {
+                                // Create nested table if it doesn't exist
+                                let next: Value = current.get(part_lower.clone())?;
+                                let next_table = match next {
+                                    Value::Table(t) => t,
+                                    _ => {
+                                        let t = lua.create_table()?;
+                                        current.set(part_lower, t.clone())?;
+                                        t
+                                    }
+                                };
+                                current = next_table;
+                            }
+                        }
+                    }
+                }
+            }
+
+            Ok(Value::Table(table))
+        })?,
+    )?;
+
+    Ok(config_module)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_env_direct_access() {
+        let lua = Lua::new();
+        let env_module = create_env_module(&lua).unwrap();
+
+        // Set a test env var
+        unsafe { std::env::set_var("ROVER_TEST_VAR", "test_value") };
+
+        // Test direct access via __index
+        let result: Value = env_module.get("ROVER_TEST_VAR").unwrap();
+
+        match result {
+            Value::String(s) => {
+                assert_eq!(s.to_str().unwrap(), "test_value");
+            }
+            _ => panic!("Expected string value, got {:?}", result),
+        }
+
+        // Clean up
+        unsafe { std::env::remove_var("ROVER_TEST_VAR") };
+    }
+
+    #[test]
+    fn test_env_missing_var_returns_nil() {
+        let lua = Lua::new();
+        let env_module = create_env_module(&lua).unwrap();
+
+        // Access non-existent var should return nil
+        let result: Value = env_module.get("ROVER_NONEXISTENT_VAR").unwrap();
+        assert!(matches!(result, Value::Nil));
+    }
+
+    #[test]
+    fn test_env_readonly() {
+        let lua = Lua::new();
+        let env_module = create_env_module(&lua).unwrap();
+
+        // Attempting to set should error
+        let result: Result<(), _> = env_module.set("ROVER_SET_TEST", "set_value");
+        assert!(result.is_err());
+
+        // Verify the error message mentions read-only
+        if let Err(e) = result {
+            let msg = e.to_string();
+            assert!(msg.contains("read-only"));
+        }
+    }
+
+    #[test]
+    fn test_config_load() {
+        let lua = Lua::new();
+        let config_module = create_config_module(&lua).unwrap();
+
+        // Create a temp config file
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join("test_config.lua");
+        std::fs::write(&config_path, "return { name = 'test', value = 42 }").unwrap();
+
+        let load_fn: mlua::Function = config_module.get("load").unwrap();
+        let result: Value = load_fn.call(config_path.to_str().unwrap()).unwrap();
+
+        match result {
+            Value::Table(t) => {
+                let name: String = t.get("name").unwrap();
+                let value: i64 = t.get("value").unwrap();
+                assert_eq!(name, "test");
+                assert_eq!(value, 42);
+            }
+            _ => panic!("Expected table"),
+        }
+    }
+
+    #[test]
+    fn test_config_from_env() {
+        let lua = Lua::new();
+        let config_module = create_config_module(&lua).unwrap();
+
+        // Set some test env vars
+        unsafe {
+            std::env::set_var("ROVER_CONFIG_DB_HOST", "localhost");
+            std::env::set_var("ROVER_CONFIG_DB_PORT", "5432");
+            std::env::set_var("ROVER_CONFIG_DEBUG", "true");
+        }
+
+        let from_env_fn: mlua::Function = config_module.get("from_env").unwrap();
+        let result: Value = from_env_fn.call("ROVER_CONFIG").unwrap();
+
+        match result {
+            Value::Table(t) => {
+                let db: Table = t.get("db").unwrap();
+                let host: String = db.get("host").unwrap();
+                let port: String = db.get("port").unwrap();
+                let debug: String = t.get("debug").unwrap();
+
+                assert_eq!(host, "localhost");
+                assert_eq!(port, "5432");
+                assert_eq!(debug, "true");
+            }
+            _ => panic!("Expected table"),
+        }
+
+        // Clean up
+        unsafe {
+            std::env::remove_var("ROVER_CONFIG_DB_HOST");
+            std::env::remove_var("ROVER_CONFIG_DB_PORT");
+            std::env::remove_var("ROVER_CONFIG_DEBUG");
+        }
+    }
+}


### PR DESCRIPTION
## Depends on
- none (base)

## Why
Need simple runtime env access in Lua apps, plus optional config loading helpers.

## What changed
- Added `rover.env` (read-only env var access)
- Added auto `.env` load at startup
- Added optional `rover.config` helpers:
  - `rover.config.load(path)`
  - `rover.config.from_env(prefix)`
- Added docs + example files

## Example
```lua
local api = rover.server {
  port = tonumber(rover.env.PORT or "4242"),
}

-- optional helper
local cfg = rover.config.from_env("APP")
```