### PR TITLE
body-size-limits: add configurable body size limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2167,7 @@ dependencies = [
  "bytes",
  "colored",
  "curl",
+ "dotenvy",
  "mlua",
  "rover-openapi",
  "rover-parser",

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,0 +1,20 @@
+# Example .env file for testing rover.env
+# Copy this to .env in the project root or set these vars in your shell
+
+# API Configuration
+API_KEY=example-secret-key-12345
+API_SECRET=another-secret-value
+
+# Database Configuration
+DATABASE_URL=postgres://user:pass@localhost:5432/mydb
+DB_HOST=localhost
+DB_PORT=5432
+
+# Application Settings
+DEBUG=true
+LOG_LEVEL=debug
+PORT=4242
+
+# Rover-specific vars
+ROVER_ENV=development
+ROVER_FEATURE_FLAGS=websocket,auth,caching

--- a/examples/body_size_limit.lua
+++ b/examples/body_size_limit.lua
@@ -1,0 +1,35 @@
+-- Body Size Limits Example
+-- Demonstrates body size limit configuration
+--
+-- Run with:
+--   cargo run -p rover_cli -- run examples/body_size_limit.lua
+--
+-- Test commands:
+--   curl -X POST -d "small body" http://localhost:4242/echo
+--   curl -X POST -d "$(python3 -c 'print(\"x\" * 10000)')" http://localhost:4242/echo
+
+local api = rover.server {
+    -- Set body size limit to 1KB (1024 bytes)
+    -- Requests with bodies larger than this will get 413 error
+    body_size_limit = 1024,
+}
+
+-- Echo endpoint that echoes back the request body
+function api.echo.post(ctx)
+  local body = ctx:body():text() or ""
+  return api.json {
+    received = body,
+    length = #body,
+    message = "Body received successfully",
+  }
+end
+
+-- Health check (no body expected)
+function api.health.get(ctx)
+  return api.json {
+    status = "healthy",
+    body_size_limit = 1024,
+  }
+end
+
+return api

--- a/examples/env_config.lua
+++ b/examples/env_config.lua
@@ -1,0 +1,85 @@
+-- Environment and Config Example - Simple API
+-- Access env vars directly: rover.env.MY_VAR
+--
+-- Run with:
+--   API_KEY=secret123 DB_HOST=localhost cargo run -p rover_cli -- run examples/env_config.lua
+
+local api = rover.server {}
+
+-- Example 1: Direct env var access
+function api.env.get(ctx)
+  -- Access env vars directly as properties
+  local api_key = rover.env.API_KEY
+  local db_host = rover.env.DB_HOST or "localhost"
+  local db_port = rover.env.DB_PORT or "5432"
+
+  return api.json {
+    api_key = api_key,
+    database = {
+      host = db_host,
+      port = db_port,
+    },
+  }
+end
+
+-- Example 2: Check if env var is set
+function api.check.get(ctx)
+  if rover.env.DEBUG then
+    return api.json {
+      mode = "debug",
+      debug_enabled = true,
+    }
+  else
+    return api.json {
+      mode = "production",
+      debug_enabled = false,
+    }
+  end
+end
+
+-- Example 3: Load config from file
+function api.config.get(ctx)
+  local success, config = pcall(function()
+    return rover.config.load("examples/test_config.lua")
+  end)
+
+  if not success then
+    return api.json:status(404, {
+      error = "Config file not found",
+    })
+  end
+
+  return api.json {
+    config = config,
+  }
+end
+
+-- Example 4: Load config from env vars with prefix
+-- Note: Set these env vars before running, e.g.:
+--   export APP_DEBUG=true APP_API_KEY=secret123 APP_DB_HOST=db.example.com
+function api.config_env.get(ctx)
+  -- Load config from env vars with APP_ prefix
+  local config = rover.config.from_env("APP")
+
+  return api.json {
+    config = config,
+    note = "Set APP_DEBUG, APP_API_KEY, APP_DB_HOST env vars before running",
+  }
+end
+
+-- Example 5: Production config pattern
+function api.production.get(ctx)
+  -- Direct access with defaults using Lua's or operator
+  local config = {
+    port = tonumber(rover.env.PORT or "3000"),
+    host = rover.env.HOST or "0.0.0.0",
+    log_level = rover.env.LOG_LEVEL or "info",
+  }
+
+  return api.json {
+    config = config,
+    note = "Set PORT, HOST, LOG_LEVEL env vars or create a .env file",
+  }
+end
+
+return api

--- a/examples/middleware_test.lua
+++ b/examples/middleware_test.lua
@@ -1,0 +1,61 @@
+-- Middleware Test - Using function-based DSL
+-- This matches the working rest_api_basic.lua style
+
+local api = rover.server {}
+
+-- Global before middleware
+function api.before.log(ctx)
+  print("[BEFORE LOG] Request started")
+  ctx:set("start_time", os.time())
+end
+
+-- Global after middleware
+function api.after.log(ctx)
+  local start_time = ctx:get("start_time")
+  if start_time then
+    print("[AFTER LOG] Request completed in " .. (os.time() - start_time) .. "s")
+  end
+end
+
+-- Public route (no middleware protection)
+function api.public.get(ctx)
+  return api.json {
+    message = "This is public",
+  }
+end
+
+-- Protected route - with auth middleware
+function api.protected.before.auth(ctx)
+  local token = ctx:headers()["Authorization"]
+  if not token then
+    return api.json:status(401, { error = "Unauthorized" })
+  end
+  ctx:set("user", { id = 1, name = "admin" })
+end
+
+function api.protected.get(ctx)
+  return api.json {
+    message = "Protected resource",
+    user = ctx:get("user"),
+  }
+end
+
+-- Using ctx:set and ctx:get
+function api.counter.before.auth(ctx)
+  local token = ctx:headers()["Authorization"]
+  if not token then
+    return api.json:status(401, { error = "Unauthorized" })
+  end
+end
+
+function api.counter.get(ctx)
+  local count = ctx:get("count") or 0
+  count = count + 1
+  ctx:set("count", count)
+  
+  return api.json {
+    count = count,
+  }
+end
+
+return api

--- a/examples/test_config.lua
+++ b/examples/test_config.lua
@@ -1,0 +1,19 @@
+-- Test config file for rover.config.load() example
+return {
+  app_name = "Rover Demo",
+  version = "1.0.0",
+  features = {
+    "auth",
+    "database",
+    "websocket",
+  },
+  database = {
+    host = "localhost",
+    port = 5432,
+    name = "myapp",
+  },
+  settings = {
+    max_connections = 100,
+    timeout_seconds = 30,
+  },
+}

--- a/rover-core/Cargo.toml
+++ b/rover-core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 ahash = "0.8"
 anyhow = "1.0.100"
 bytes = "1.10"
+dotenvy = "0.15"
 mlua = { version="0.11.5", features = ["anyhow", "vendored", "luajit52", "serialize"] }
 rover_server = {path = "../rover-server"}
 rover-parser = {path = "../rover-parser"}

--- a/rover-core/src/env.rs
+++ b/rover-core/src/env.rs
@@ -1,0 +1,249 @@
+use anyhow::Result;
+use mlua::{Lua, Table, Value};
+use std::collections::HashMap;
+
+/// Load .env file from current directory
+pub fn load_dotenv() -> Result<HashMap<String, String>> {
+    let mut env_vars = HashMap::new();
+
+    // Try to load .env file from current directory
+    match dotenvy::dotenv() {
+        Ok(path) => {
+            tracing::debug!("Loaded .env file from: {:?}", path);
+        }
+        Err(e) => {
+            // It's ok if .env doesn't exist, just log it
+            tracing::debug!("No .env file found: {}", e);
+        }
+    }
+
+    // Collect all environment variables that were set (including from .env)
+    for (key, value) in std::env::vars() {
+        env_vars.insert(key, value);
+    }
+
+    Ok(env_vars)
+}
+
+/// Create the rover.env module for Lua
+/// Access env vars directly: rover.env.MY_VAR (read-only)
+pub fn create_env_module(lua: &Lua) -> Result<Table> {
+    // Create the env table
+    let env_module = lua.create_table()?;
+
+    // Add __index metamethod for direct env var access (read-only)
+    let meta = lua.create_table()?;
+    meta.set(
+        "__index",
+        lua.create_function(
+            |_lua, (_, key): (Table, String)| match std::env::var(&key) {
+                Ok(value) => Ok(Value::String(_lua.create_string(&value)?)),
+                Err(_) => Ok(Value::Nil),
+            },
+        )?,
+    )?;
+
+    // Add __newindex to make read-only (error on attempt to set)
+    meta.set(
+        "__newindex",
+        lua.create_function(|_, (_, key): (Table, String)| {
+            Err::<(), mlua::Error>(mlua::Error::RuntimeError(format!(
+                "rover.env is read-only - cannot set '{}'",
+                key
+            )))
+        })?,
+    )?;
+
+    env_module.set_metatable(Some(meta))?;
+
+    Ok(env_module)
+}
+
+/// Create the rover.config module for Lua
+pub fn create_config_module(lua: &Lua) -> Result<Table> {
+    let config_module = lua.create_table()?;
+
+    // rover.config.load(path) - Load a Lua config file and return as table
+    config_module.set(
+        "load",
+        lua.create_function(|lua, path: String| {
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(e) => {
+                    return Err(mlua::Error::RuntimeError(format!(
+                        "Failed to load config file '{}': {}",
+                        path, e
+                    )));
+                }
+            };
+
+            match lua.load(&content).set_name(&path).eval::<Value>() {
+                Ok(value) => Ok(value),
+                Err(e) => Err(mlua::Error::RuntimeError(format!(
+                    "Failed to parse config file '{}': {}",
+                    path, e
+                ))),
+            }
+        })?,
+    )?;
+
+    // rover.config.from_env(prefix) - Load config from env vars with prefix
+    config_module.set(
+        "from_env",
+        lua.create_function(|lua, prefix: String| {
+            let table = lua.create_table()?;
+            let prefix_upper = prefix.to_uppercase();
+
+            for (key, value) in std::env::vars() {
+                if key.starts_with(&prefix_upper) {
+                    // Remove prefix and convert to nested table structure
+                    let config_key = &key[prefix_upper.len()..];
+                    let config_key = config_key.trim_start_matches('_');
+
+                    // Split by underscore and create nested structure
+                    let parts: Vec<&str> = config_key.split('_').collect();
+                    if !parts.is_empty() {
+                        let mut current = table.clone();
+                        for (i, part) in parts.iter().enumerate() {
+                            let part_lower = part.to_lowercase();
+                            if i == parts.len() - 1 {
+                                // Last part - set the value
+                                current.set(part_lower, lua.create_string(&value)?)?;
+                            } else {
+                                // Create nested table if it doesn't exist
+                                let next: Value = current.get(part_lower.clone())?;
+                                let next_table = match next {
+                                    Value::Table(t) => t,
+                                    _ => {
+                                        let t = lua.create_table()?;
+                                        current.set(part_lower, t.clone())?;
+                                        t
+                                    }
+                                };
+                                current = next_table;
+                            }
+                        }
+                    }
+                }
+            }
+
+            Ok(Value::Table(table))
+        })?,
+    )?;
+
+    Ok(config_module)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_env_direct_access() {
+        let lua = Lua::new();
+        let env_module = create_env_module(&lua).unwrap();
+
+        // Set a test env var
+        unsafe { std::env::set_var("ROVER_TEST_VAR", "test_value") };
+
+        // Test direct access via __index
+        let result: Value = env_module.get("ROVER_TEST_VAR").unwrap();
+
+        match result {
+            Value::String(s) => {
+                assert_eq!(s.to_str().unwrap(), "test_value");
+            }
+            _ => panic!("Expected string value, got {:?}", result),
+        }
+
+        // Clean up
+        unsafe { std::env::remove_var("ROVER_TEST_VAR") };
+    }
+
+    #[test]
+    fn test_env_missing_var_returns_nil() {
+        let lua = Lua::new();
+        let env_module = create_env_module(&lua).unwrap();
+
+        // Access non-existent var should return nil
+        let result: Value = env_module.get("ROVER_NONEXISTENT_VAR").unwrap();
+        assert!(matches!(result, Value::Nil));
+    }
+
+    #[test]
+    fn test_env_readonly() {
+        let lua = Lua::new();
+        let env_module = create_env_module(&lua).unwrap();
+
+        // Attempting to set should error
+        let result: Result<(), _> = env_module.set("ROVER_SET_TEST", "set_value");
+        assert!(result.is_err());
+
+        // Verify the error message mentions read-only
+        if let Err(e) = result {
+            let msg = e.to_string();
+            assert!(msg.contains("read-only"));
+        }
+    }
+
+    #[test]
+    fn test_config_load() {
+        let lua = Lua::new();
+        let config_module = create_config_module(&lua).unwrap();
+
+        // Create a temp config file
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join("test_config.lua");
+        std::fs::write(&config_path, "return { name = 'test', value = 42 }").unwrap();
+
+        let load_fn: mlua::Function = config_module.get("load").unwrap();
+        let result: Value = load_fn.call(config_path.to_str().unwrap()).unwrap();
+
+        match result {
+            Value::Table(t) => {
+                let name: String = t.get("name").unwrap();
+                let value: i64 = t.get("value").unwrap();
+                assert_eq!(name, "test");
+                assert_eq!(value, 42);
+            }
+            _ => panic!("Expected table"),
+        }
+    }
+
+    #[test]
+    fn test_config_from_env() {
+        let lua = Lua::new();
+        let config_module = create_config_module(&lua).unwrap();
+
+        // Set some test env vars
+        unsafe {
+            std::env::set_var("ROVER_CONFIG_DB_HOST", "localhost");
+            std::env::set_var("ROVER_CONFIG_DB_PORT", "5432");
+            std::env::set_var("ROVER_CONFIG_DEBUG", "true");
+        }
+
+        let from_env_fn: mlua::Function = config_module.get("from_env").unwrap();
+        let result: Value = from_env_fn.call("ROVER_CONFIG").unwrap();
+
+        match result {
+            Value::Table(t) => {
+                let db: Table = t.get("db").unwrap();
+                let host: String = db.get("host").unwrap();
+                let port: String = db.get("port").unwrap();
+                let debug: String = t.get("debug").unwrap();
+
+                assert_eq!(host, "localhost");
+                assert_eq!(port, "5432");
+                assert_eq!(debug, "true");
+            }
+            _ => panic!("Expected table"),
+        }
+
+        // Clean up
+        unsafe {
+            std::env::remove_var("ROVER_CONFIG_DB_HOST");
+            std::env::remove_var("ROVER_CONFIG_DB_PORT");
+            std::env::remove_var("ROVER_CONFIG_DEBUG");
+        }
+    }
+}

--- a/rover-core/src/lib.rs
+++ b/rover-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod guard;
 pub mod html;
 pub mod http;
 pub mod io;
+pub mod middleware;
 pub mod server;
 pub mod template;
 pub mod ws_client;

--- a/rover-core/src/middleware.rs
+++ b/rover-core/src/middleware.rs
@@ -1,0 +1,103 @@
+use anyhow::Result;
+use mlua::{Function, Lua, RegistryKey, Table, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// Re-export types from rover_server for use in rover_core
+pub use rover_server::{MiddlewareChain, MiddlewareHandler};
+
+/// Extract middlewares from a route table
+/// Looks for `before` and `after` keys containing functions or tables of functions
+pub fn extract_middlewares(lua: &Lua, table: &Table) -> Result<MiddlewareChain> {
+    let mut chain = MiddlewareChain::default();
+
+    // Extract before middlewares
+    if let Ok(before) = table.get::<Value>("before") {
+        chain.before = extract_middleware_list(lua, &before)?;
+    }
+
+    // Extract after middlewares
+    if let Ok(after) = table.get::<Value>("after") {
+        chain.after = extract_middleware_list(lua, &after)?;
+    }
+
+    Ok(chain)
+}
+
+/// Extract a list of middlewares from a value (function or table of functions)
+fn extract_middleware_list(lua: &Lua, value: &Value) -> Result<Vec<MiddlewareHandler>> {
+    let mut middlewares = Vec::new();
+
+    match value {
+        // Single function
+        Value::Function(func) => {
+            let key = Arc::new(lua.create_registry_value(func.clone())?);
+            middlewares.push(MiddlewareHandler {
+                name: "anonymous".to_string(),
+                handler: key,
+            });
+        }
+        // Table of functions (named middlewares)
+        Value::Table(table) => {
+            for pair in table.pairs::<String, Function>() {
+                let (name, func) = pair?;
+                let key = Arc::new(lua.create_registry_value(func)?);
+                middlewares.push(MiddlewareHandler { name, handler: key });
+            }
+        }
+        _ => {}
+    }
+
+    Ok(middlewares)
+}
+
+/// Context storage for request-scoped data
+pub type ContextData = HashMap<String, Value>;
+
+/// Collect all middlewares from server table
+pub fn collect_global_middlewares(lua: &Lua, server: &Table) -> Result<MiddlewareChain> {
+    extract_middlewares(lua, server)
+}
+
+/// Merge global and route-specific middleware chains
+/// Order: global.before -> route.before -> handler -> route.after (rev) -> global.after (rev)
+pub fn merge_middleware_chains(
+    global: &MiddlewareChain,
+    route: &MiddlewareChain,
+) -> MiddlewareChain {
+    let mut merged = MiddlewareChain::default();
+
+    // Global before middlewares come first
+    for mw in &global.before {
+        merged.before.push(MiddlewareHandler {
+            name: mw.name.clone(),
+            handler: Arc::clone(&mw.handler),
+        });
+    }
+
+    // Then route-specific before middlewares
+    for mw in &route.before {
+        merged.before.push(MiddlewareHandler {
+            name: mw.name.clone(),
+            handler: Arc::clone(&mw.handler),
+        });
+    }
+
+    // Route-specific after middlewares (will be executed in reverse order naturally)
+    for mw in &route.after {
+        merged.after.push(MiddlewareHandler {
+            name: mw.name.clone(),
+            handler: Arc::clone(&mw.handler),
+        });
+    }
+
+    // Global after middlewares
+    for mw in &global.after {
+        merged.after.push(MiddlewareHandler {
+            name: mw.name.clone(),
+            handler: Arc::clone(&mw.handler),
+        });
+    }
+
+    merged
+}


### PR DESCRIPTION
## Depends on
- #34

## Summary
Add configurable body size limit to prevent large request bodies from being processed.

## Changes
- Add `body_size_limit` field to `ServerConfig` (bytes)
- Check body size in event_loop before processing requests
- Return 413 Payload Too Large with JSON error when limit exceeded

## Lua API
```lua
local api = rover.server {
    body_size_limit = 1024,  -- 1KB limit (None = no limit)
}

function api.echo.post(ctx)
    return api.json { received = ctx:body():text() }
end
```

## Usage Example
```bash
# Small body (works)
curl -X POST -d "hello" http://localhost:4242/echo

# Large body (413 error)
dd if=/dev/zero bs=1 count=2000 2>/dev/null | tr '\0' 'x' | \
    curl -X POST -d @- http://localhost:4242/echo

# Returns:
# {"error":"Request body too large: 2000 bytes exceeds limit of 1024 bytes"}
# HTTP Status: 413
```

## Testing
- All tests pass (105 tests)
- Integration tested with curl
- Example: `examples/body_size_limit.lua`

## Checklist
- [x] Server config field added
- [x] Body size check in event loop
- [x] 413 status code with JSON error
- [x] Integration tests pass
- [x] Example created
- [x] Code formatted