### PR TITLE
authentication-system: add JWT authentication with rover-auth crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,8 +952,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1383,6 +1394,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1758,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +1882,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,6 +1982,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2095,6 +2162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rover-auth"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "jsonwebtoken",
+ "mlua",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "rover-lsp"
 version = "0.1.0"
 dependencies = [
@@ -2169,6 +2247,7 @@ dependencies = [
  "curl",
  "dotenvy",
  "mlua",
+ "rover-auth",
  "rover-openapi",
  "rover-parser",
  "rover_db",
@@ -2598,6 +2677,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +2933,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["rover-cli" , "rover-core", "rover-server", "rover-lsp", "rover-parser", "rover-types", "rover-db", "rover-ui", "rover-runtime", "rover-bundler", "rover-tui"]
+members = ["rover-cli" , "rover-core", "rover-server", "rover-lsp", "rover-parser", "rover-types", "rover-db", "rover-ui", "rover-runtime", "rover-bundler", "rover-tui", "rover-auth"]
 
 [profile.release]
 opt-level = 3

--- a/examples/error_handling.lua
+++ b/examples/error_handling.lua
@@ -1,0 +1,63 @@
+-- Error Handling Middleware Example
+-- Demonstrates centralized error handling
+--
+-- Run with:
+--   cargo run -p rover_cli -- run examples/error_handling.lua
+--
+-- Test commands:
+--   curl http://localhost:4242/divide?a=10&b=2    # Success
+--   curl http://localhost:4242/divide?a=10&b=0    # Division by zero error
+--   curl http://localhost:4242/divide?a=abc&b=2    # Invalid number error
+
+local api = rover.server {}
+
+-- Global error handler
+-- Catches all errors and formats them consistently
+function api.on_error(err)
+  -- Log the error
+  print("[ERROR] " .. err.message)
+  
+  -- Return formatted error response
+  return api.json:status(err.status or 500, {
+    error = err.message,
+    code = err.code or "INTERNAL_ERROR",
+    path = err.path,
+    timestamp = os.time(),
+  })
+end
+
+-- Divide endpoint that can throw errors
+function api.divide.get(ctx)
+  local query = ctx:query()
+  local a = tonumber(query.a)
+  local b = tonumber(query.b)
+  
+  -- Validation errors (400)
+  if not a then
+    error("Validation failed: Parameter 'a' is required and must be a number")
+  end
+  
+  if not b then
+    error("Validation failed: Parameter 'b' is required and must be a number")
+  end
+  
+  -- Business logic error (422)
+  if b == 0 then
+    error("Validation failed: Division by zero is not allowed")
+  end
+  
+  -- Success
+  return api.json {
+    result = a / b,
+    a = a,
+    b = b,
+  }
+end
+
+-- Simulate internal server error
+function api.crash.get(ctx)
+  -- This will trigger 500 error
+  error("Database connection failed")
+end
+
+return api

--- a/examples/jwt_auth.lua
+++ b/examples/jwt_auth.lua
@@ -1,0 +1,97 @@
+-- JWT Authentication Example
+-- Demonstrates rover.auth module for JWT tokens
+--
+-- Run with:
+--   cargo run -p rover_cli -- run examples/jwt_auth.lua
+--
+-- Test commands:
+--   # Create a token
+--   curl -X POST http://localhost:4242/login -d '{"user_id": "123", "role": "admin"}'
+--
+--   # Access protected route with token
+--   curl http://localhost:4242/protected -H "Authorization: Bearer <token>"
+
+local api = rover.server {}
+
+-- Secret key for JWT signing (use env var in production!)
+local JWT_SECRET = rover.env.JWT_SECRET or "my-secret-key-change-in-production"
+
+-- Login endpoint - creates JWT token
+function api.login.post(ctx)
+  local body = ctx:body():json() or {}
+  
+  -- Validate credentials (simplified example)
+  if not body.user_id then
+    error("user_id required")
+  end
+  
+  -- Create JWT claims
+  local claims = {
+    sub = body.user_id,
+    role = body.role or "user",
+    iat = os.time(),
+    exp = os.time() + 3600,  -- 1 hour expiration
+  }
+  
+  -- Generate token
+  local token = rover.auth.create(claims, JWT_SECRET)
+  
+  return api.json {
+    token = token,
+    expires_in = 3600,
+  }
+end
+
+-- Protected route - requires valid JWT
+function api.protected.before.auth(ctx)
+  local headers = ctx:headers()
+  local auth_header = headers["Authorization"]
+  
+  if not auth_header then
+    return api.json:status(401, { error = "Missing Authorization header" })
+  end
+  
+  -- Extract token from "Bearer <token>"
+  local token = auth_header:match("Bearer%s+(.+)")
+  if not token then
+    return api.json:status(401, { error = "Invalid Authorization format" })
+  end
+  
+  -- Verify token
+  local result = rover.auth.verify(token, JWT_SECRET)
+  
+  if not result.valid then
+    return api.json:status(401, { error = "Invalid token: " .. (result.error or "") })
+  end
+  
+  -- Store user info in context for the handler
+  ctx:set("user", {
+    id = result.sub,
+    role = result.role,
+  })
+end
+
+function api.protected.get(ctx)
+  local user = ctx:get("user")
+  
+  return api.json {
+    message = "Protected resource",
+    user = user,
+  }
+end
+
+-- Decode endpoint - inspect token without verification
+function api.decode.post(ctx)
+  local body = ctx:body():json() or {}
+  
+  if not body.token then
+    error("token required")
+  end
+  
+  -- Decode without verification (for inspection only)
+  local decoded = rover.auth.decode(body.token)
+  
+  return api.json(decoded)
+end
+
+return api

--- a/rover-auth/Cargo.toml
+++ b/rover-auth/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rover-auth"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+jsonwebtoken = "9.3"
+serde = { version = "1.0", features = ["derive"] }
+mlua = { version = "0.11.5", features = ["anyhow", "vendored", "luajit52", "serialize"] }
+serde_json = "1.0"

--- a/rover-auth/src/lib.rs
+++ b/rover-auth/src/lib.rs
@@ -1,0 +1,297 @@
+use anyhow::{anyhow, Result};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use mlua::{Lua, Table, Value};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// JWT Claims structure
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    /// Subject (user identifier)
+    pub sub: String,
+    /// Issued at (timestamp)
+    pub iat: Option<i64>,
+    /// Expiration (timestamp)
+    pub exp: Option<i64>,
+    /// Issuer
+    pub iss: Option<String>,
+    /// Audience
+    pub aud: Option<String>,
+    /// Custom claims
+    #[serde(flatten)]
+    pub custom: HashMap<String, serde_json::Value>,
+}
+
+/// Create JWT token
+fn create_token(
+    lua: &Lua,
+    (claims_table, secret, algorithm): (Table, String, Option<String>),
+) -> mlua::Result<String> {
+    let sub: String = claims_table.get("sub")?;
+    let iat: Option<i64> = claims_table.get("iat")?;
+    let exp: Option<i64> = claims_table.get("exp")?;
+    let iss: Option<String> = claims_table.get("iss")?;
+    let aud: Option<String> = claims_table.get("aud")?;
+
+    // Extract custom claims
+    let mut custom = HashMap::new();
+    for pair in claims_table.pairs::<Value, Value>() {
+        let (key, value) = pair?;
+        if let Value::String(key_str) = key {
+            let key = key_str.to_str()?.to_string();
+            // Skip standard claims
+            if key != "sub" && key != "iat" && key != "exp" && key != "iss" && key != "aud" {
+                let json_value = lua_value_to_json(&value)?;
+                custom.insert(key, json_value);
+            }
+        }
+    }
+
+    let claims = Claims {
+        sub,
+        iat,
+        exp,
+        iss,
+        aud,
+        custom,
+    };
+
+    let header = Header::default();
+    let encoding_key = EncodingKey::from_secret(secret.as_bytes());
+
+    let token = encode(&header, &claims, &encoding_key)
+        .map_err(|e| mlua::Error::RuntimeError(format!("Failed to create JWT: {}", e)))?;
+
+    Ok(token)
+}
+
+/// Verify JWT token
+fn verify_token(
+    lua: &Lua,
+    (token, secret, algorithm): (String, String, Option<String>),
+) -> mlua::Result<Value> {
+    let validation = Validation::default();
+    let decoding_key = DecodingKey::from_secret(secret.as_bytes());
+
+    match decode::<Claims>(&token, &decoding_key, &validation) {
+        Ok(token_data) => {
+            let claims = token_data.claims;
+
+            // Convert to Lua table
+            let table = lua.create_table()?;
+            table.set("sub", claims.sub)?;
+            if let Some(iat) = claims.iat {
+                table.set("iat", iat)?;
+            }
+            if let Some(exp) = claims.exp {
+                table.set("exp", exp)?;
+            }
+            if let Some(iss) = claims.iss {
+                table.set("iss", iss)?;
+            }
+            if let Some(aud) = claims.aud {
+                table.set("aud", aud)?;
+            }
+
+            // Add custom claims
+            for (key, value) in claims.custom {
+                let lua_value = json_value_to_lua(lua, &value)?;
+                table.set(key, lua_value)?;
+            }
+
+            table.set("valid", true)?;
+            Ok(Value::Table(table))
+        }
+        Err(e) => {
+            let table = lua.create_table()?;
+            table.set("valid", false)?;
+            table.set("error", format!("{}", e))?;
+            Ok(Value::Table(table))
+        }
+    }
+}
+
+/// Decode JWT token without verification (for inspection)
+fn decode_token(lua: &Lua, token: String) -> mlua::Result<Value> {
+    match decode::<Claims>(
+        &token,
+        &DecodingKey::from_secret(&[]),
+        &Validation::default(),
+    ) {
+        Ok(token_data) => {
+            let claims = token_data.claims;
+
+            let table = lua.create_table()?;
+            table.set("sub", claims.sub)?;
+            if let Some(iat) = claims.iat {
+                table.set("iat", iat)?;
+            }
+            if let Some(exp) = claims.exp {
+                table.set("exp", exp)?;
+            }
+            if let Some(iss) = claims.iss {
+                table.set("iss", iss)?;
+            }
+            if let Some(aud) = claims.aud {
+                table.set("aud", aud)?;
+            }
+
+            // Add custom claims
+            for (key, value) in claims.custom {
+                let lua_value = json_value_to_lua(lua, &value)?;
+                table.set(key, lua_value)?;
+            }
+
+            table.set("valid", true)?;
+            Ok(Value::Table(table))
+        }
+        Err(e) => {
+            let table = lua.create_table()?;
+            table.set("valid", false)?;
+            table.set("error", format!("{}", e))?;
+            Ok(Value::Table(table))
+        }
+    }
+}
+
+/// Convert Lua value to JSON value
+fn lua_value_to_json(value: &Value) -> mlua::Result<serde_json::Value> {
+    match value {
+        Value::Nil => Ok(serde_json::Value::Null),
+        Value::Boolean(b) => Ok(serde_json::Value::Bool(*b)),
+        Value::Integer(i) => Ok(serde_json::Value::Number((*i).into())),
+        Value::Number(n) => Ok(serde_json::json!(n)),
+        Value::String(s) => Ok(serde_json::Value::String(s.to_str()?.to_string())),
+        Value::Table(t) => {
+            // Check if it's an array
+            let mut is_array = true;
+            let mut array_values = Vec::new();
+            let mut object_values = HashMap::new();
+
+            for pair in t.clone().pairs::<Value, Value>() {
+                let (key, val) = pair?;
+                match key {
+                    Value::Integer(i) if i > 0 => {
+                        array_values.push((i as usize - 1, lua_value_to_json(&val)?));
+                    }
+                    Value::String(s) => {
+                        is_array = false;
+                        object_values.insert(s.to_str()?.to_string(), lua_value_to_json(&val)?);
+                    }
+                    _ => {
+                        is_array = false;
+                    }
+                }
+            }
+
+            if is_array && !array_values.is_empty() {
+                array_values.sort_by_key(|(i, _)| *i);
+                let arr: Vec<_> = array_values.into_iter().map(|(_, v)| v).collect();
+                Ok(serde_json::Value::Array(arr))
+            } else {
+                Ok(serde_json::Value::Object(
+                    object_values.into_iter().collect(),
+                ))
+            }
+        }
+        _ => Err(mlua::Error::RuntimeError(
+            "Cannot convert Lua value to JSON".to_string(),
+        )),
+    }
+}
+
+/// Convert JSON value to Lua value
+fn json_value_to_lua(lua: &Lua, value: &serde_json::Value) -> mlua::Result<Value> {
+    match value {
+        serde_json::Value::Null => Ok(Value::Nil),
+        serde_json::Value::Bool(b) => Ok(Value::Boolean(*b)),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(Value::Integer(i))
+            } else if let Some(f) = n.as_f64() {
+                Ok(Value::Number(f))
+            } else {
+                Ok(Value::Nil)
+            }
+        }
+        serde_json::Value::String(s) => Ok(Value::String(lua.create_string(s)?)),
+        serde_json::Value::Array(arr) => {
+            let table = lua.create_table()?;
+            for (i, val) in arr.iter().enumerate() {
+                table.set(i + 1, json_value_to_lua(lua, val)?)?;
+            }
+            Ok(Value::Table(table))
+        }
+        serde_json::Value::Object(obj) => {
+            let table = lua.create_table()?;
+            for (key, val) in obj.iter() {
+                table.set(key.as_str(), json_value_to_lua(lua, val)?)?;
+            }
+            Ok(Value::Table(table))
+        }
+    }
+}
+
+/// Create the rover.auth module
+pub fn create_auth_module(lua: &Lua) -> Result<Table> {
+    let auth_module = lua.create_table()?;
+
+    // rover.auth.create(claims, secret) - Create JWT token
+    auth_module.set("create", lua.create_function(create_token)?)?;
+
+    // rover.auth.verify(token, secret) - Verify JWT token
+    auth_module.set("verify", lua.create_function(verify_token)?)?;
+
+    // rover.auth.decode(token) - Decode JWT without verification
+    auth_module.set("decode", lua.create_function(decode_token)?)?;
+
+    Ok(auth_module)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_and_verify_token() {
+        let lua = Lua::new();
+        let claims_table = lua.create_table().unwrap();
+        claims_table.set("sub", "user123").unwrap();
+        claims_table.set("role", "admin").unwrap();
+        // Set expiration far in the future to avoid "expired" errors
+        claims_table.set("exp", 9999999999i64).unwrap();
+
+        let secret = "my-secret-key".to_string();
+        let token = create_token(&lua, (claims_table, secret.clone(), None)).unwrap();
+
+        // Verify the token
+        let result = verify_token(&lua, (token, secret, None)).unwrap();
+
+        if let Value::Table(t) = result {
+            let valid: bool = t.get("valid").unwrap();
+            assert!(valid, "Token should be valid");
+            let sub: String = t.get("sub").unwrap();
+            assert_eq!(sub, "user123");
+            let role: String = t.get("role").unwrap();
+            assert_eq!(role, "admin");
+        } else {
+            panic!("Expected table");
+        }
+    }
+
+    #[test]
+    fn test_verify_invalid_token() {
+        let lua = Lua::new();
+        let token = "invalid.token.here".to_string();
+        let secret = "my-secret-key".to_string();
+
+        let result = verify_token(&lua, (token, secret, None)).unwrap();
+
+        if let Value::Table(t) = result {
+            let valid: bool = t.get("valid").unwrap();
+            assert!(!valid);
+        } else {
+            panic!("Expected table");
+        }
+    }
+}

--- a/rover-core/Cargo.toml
+++ b/rover-core/Cargo.toml
@@ -15,6 +15,7 @@ rover-openapi = {path = "../rover-openapi"}
 rover_types = {path = "../rover-types"}
 rover_db = {path = "../rover-db"}
 rover_ui = {path = "../rover-ui"}
+rover-auth = {path = "../rover-auth"}
 serde_json = "1.0"
 tracing = "0.1"
 smallvec = "1.15.1"

--- a/rover-core/src/lib.rs
+++ b/rover-core/src/lib.rs
@@ -15,13 +15,14 @@ use env::{create_config_module, create_env_module, load_dotenv};
 use html::create_html_module;
 use http::create_http_module;
 use io::create_io_module;
+use rover_auth::create_auth_module;
 use rover_db::create_db_module;
 use rover_ui::platform::{
-    DEFAULT_VIEWPORT_HEIGHT, DEFAULT_VIEWPORT_WIDTH, UiRuntimeConfig, UiTarget, ViewportSignals,
+    UiRuntimeConfig, UiTarget, ViewportSignals, DEFAULT_VIEWPORT_HEIGHT, DEFAULT_VIEWPORT_WIDTH,
 };
 use rover_ui::scheduler::{Scheduler, SharedScheduler};
 use rover_ui::signal::SignalValue;
-use rover_ui::{SharedSignalRuntime, SignalRuntime, register_ui_module, ui::UiRegistry};
+use rover_ui::{register_ui_module, ui::UiRegistry, SharedSignalRuntime, SignalRuntime};
 use server::{AppServer, Server};
 use std::cell::RefCell;
 
@@ -104,7 +105,7 @@ pub fn run(path: &str, args: &[String], verbose: bool) -> Result<()> {
     guard_meta.set(
         "__call",
         lua.create_function(|lua, (data, schema): (Value, Value)| {
-            use crate::guard::{ValidationErrors, validate_table};
+            use crate::guard::{validate_table, ValidationErrors};
 
             // Extract the table from data
             let data_table = match data {
@@ -150,6 +151,10 @@ pub fn run(path: &str, args: &[String], verbose: bool) -> Result<()> {
     // Add rover.config module for loading config files
     let config_module = create_config_module(&lua)?;
     rover.set("config", config_module)?;
+
+    // Add rover.auth JWT module
+    let auth_module = create_auth_module(&lua)?;
+    rover.set("auth", auth_module)?;
 
     // Override global io module with async version
     let io_module = io::create_io_module(&lua)?;
@@ -258,6 +263,10 @@ pub fn register_extra_modules(lua: &Lua) -> Result<()> {
     let config_module = create_config_module(lua)?;
     rover.set("config", config_module)?;
 
+    // Add rover.auth JWT module
+    let auth_module = create_auth_module(lua)?;
+    rover.set("auth", auth_module)?;
+
     // Add HTTP client module
     let http_module = create_http_module(lua)?;
     rover.set("http", http_module)?;
@@ -301,7 +310,7 @@ pub fn register_extra_modules(lua: &Lua) -> Result<()> {
     guard_meta.set(
         "__call",
         lua.create_function(|lua, (data, schema): (Value, Value)| {
-            use crate::guard::{ValidationErrors, validate_table};
+            use crate::guard::{validate_table, ValidationErrors};
 
             // Extract the table from data
             let data_table = match data {
@@ -417,7 +426,7 @@ pub fn run_from_str(source: &str, args: &[String], verbose: bool) -> Result<()> 
     guard_meta.set(
         "__call",
         lua.create_function(|lua, (data, schema): (Value, Value)| {
-            use crate::guard::{ValidationErrors, validate_table};
+            use crate::guard::{validate_table, ValidationErrors};
 
             let data_table = match data {
                 Value::Table(ref t) => t.clone(),
@@ -459,6 +468,10 @@ pub fn run_from_str(source: &str, args: &[String], verbose: bool) -> Result<()> 
     // Add rover.config module for loading config files
     let config_module = create_config_module(&lua)?;
     rover.set("config", config_module)?;
+
+    // Add rover.auth JWT module
+    let auth_module = create_auth_module(&lua)?;
+    rover.set("auth", auth_module)?;
 
     // Override global io module
     let io_module = io::create_io_module(&lua)?;

--- a/rover-server/src/http_server.rs
+++ b/rover-server/src/http_server.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
-use mlua::Lua;
+use mlua::{Lua, RegistryKey};
 use std::net::SocketAddr;
+use std::sync::Arc;
 
-use crate::{Route, ServerConfig, WsRoute, event_loop::EventLoop};
+use crate::{event_loop::EventLoop, Route, ServerConfig, WsRoute};
 
 pub fn run_server(
     lua: Lua,
@@ -11,7 +12,16 @@ pub fn run_server(
     config: ServerConfig,
     openapi_spec: Option<serde_json::Value>,
     addr: SocketAddr,
+    error_handler: Option<Arc<RegistryKey>>,
 ) -> Result<()> {
-    let mut event_loop = EventLoop::new(lua, routes, ws_routes, config, openapi_spec, addr)?;
+    let mut event_loop = EventLoop::new(
+        lua,
+        routes,
+        ws_routes,
+        config,
+        openapi_spec,
+        addr,
+        error_handler,
+    )?;
     event_loop.run()
 }

--- a/rover-server/src/lib.rs
+++ b/rover-server/src/lib.rs
@@ -137,6 +137,8 @@ pub struct WsRoute {
 pub struct RouteTable {
     pub routes: Vec<Route>,
     pub ws_routes: Vec<WsRoute>,
+    /// Optional error handler function (api.on_error)
+    pub error_handler: Option<Arc<RegistryKey>>,
 }
 
 #[derive(Debug, Clone)]
@@ -199,6 +201,7 @@ pub fn run(
     config: ServerConfig,
     openapi_spec: Option<serde_json::Value>,
 ) {
+    let error_handler = routes.error_handler.clone();
     if config.log_level != "nope" {
         tracing_subscriber::fmt()
             .with_env_filter(
@@ -245,6 +248,7 @@ pub fn run(
         config,
         openapi_spec,
         sock_addr,
+        error_handler,
     ) {
         Ok(_) => {}
         Err(e) => {

--- a/rover-server/src/ws_handshake.rs
+++ b/rover-server/src/ws_handshake.rs
@@ -1,5 +1,5 @@
-use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
 /// WebSocket handshake (RFC 6455 sec 4.2).
 ///
 /// Validates HTTP Upgrade headers using the connection's offset-based header access,


### PR DESCRIPTION
## Depends on
- #37

## Summary
Add JWT authentication support via new rover-auth crate.

## Changes
- **New crate: rover-auth** - JWT token creation and verification
- **rover.auth.create(claims, secret)** - Create JWT with claims
- **rover.auth.verify(token, secret)** - Verify and decode JWT
- **rover.auth.decode(token)** - Decode without verification

## JWT Claims
- Standard: sub, iat, exp, iss, aud
- Custom: Any Lua values supported
- Algorithm: HS256 (HMAC SHA-256)

## Lua API Example
```lua
-- Login endpoint creates JWT
function api.login.post(ctx)
  local claims = {
    sub = body.user_id,
    role = body.role,
    exp = os.time() + 3600,  -- 1 hour
  }
  local token = rover.auth.create(claims, JWT_SECRET)
  return api.json { token = token }
end

-- Protected route with auth middleware
function api.protected.before.auth(ctx)
  local token = ctx:headers()["Authorization"]:match("Bearer%s+(.+)")
  local result = rover.auth.verify(token, JWT_SECRET)
  
  if not result.valid then
    return api.json:status(401, { error = "Invalid token" })
  end
  
  ctx:set("user", { id = result.sub, role = result.role })
end
```

## Testing
```bash
# Create token
curl -X POST http://localhost:4242/login -d '{"user_id": "123", "role": "admin"}'

# Access protected with token
curl http://localhost:4242/protected -H "Authorization: Bearer TOKEN"
```

## Checklist
- [x] New rover-auth crate
- [x] JWT create/verify/decode functions
- [x] Custom claims support
- [x] Unit tests (2 passing)
- [x] Integration tested
- [x] Example: examples/jwt_auth.lua
- [x] All tests pass