### PR TITLE
routing-semantics: add 404/405 Allow + auto HEAD/OPTIONS

### DIFF
--- a/docs/docs/api-reference/route-patterns.md
+++ b/docs/docs/api-reference/route-patterns.md
@@ -75,6 +75,12 @@ Rover supports all standard HTTP methods as function suffixes:
 - `patch` - PATCH requests
 - `delete` - DELETE requests
 
+Incoming `HEAD` and `OPTIONS` are supported automatically:
+
+- `HEAD` uses the same handler as `GET` when no explicit `head` route exists.
+- `OPTIONS` returns `204 No Content` with an `Allow` header when the path exists.
+- When a path exists but method is not allowed, Rover returns `405 Method Not Allowed` with `Allow`.
+
 Example with multiple methods on the same resource:
 
 ```lua
@@ -107,6 +113,12 @@ function api.users.p_id.delete(ctx)
     return api.no_content()
 end
 ```
+
+## 404 / 405 / Allow Behavior
+
+- Unknown path: `404 Route not found`
+- Known path with unsupported method: `405 Method Not Allowed`
+- `Allow` includes supported methods plus implicit `HEAD` (when `GET` exists) and `OPTIONS`
 
 ## Best Practices
 

--- a/examples/routing_semantics.lua
+++ b/examples/routing_semantics.lua
@@ -1,0 +1,23 @@
+local api = rover.server {}
+
+function api.echo.get(ctx)
+  return api.json {
+    method = "GET",
+    ok = true,
+  }
+end
+
+function api.echo.post(ctx)
+  return api.json:status(201, {
+    method = "POST",
+    ok = true,
+  })
+end
+
+function api.users.p_id.get(ctx)
+  return api.json {
+    id = ctx:params().id,
+  }
+end
+
+return api

--- a/rover-server/src/connection.rs
+++ b/rover-server/src/connection.rs
@@ -1,5 +1,5 @@
-use crate::ws_frame;
 use crate::Bytes;
+use crate::ws_frame;
 use bytes::BytesMut;
 use mio::net::TcpStream;
 use mio::{Interest, Registry, Token};
@@ -380,6 +380,8 @@ impl Connection {
             201 => "Created",
             204 => "No Content",
             400 => "Bad Request",
+            405 => "Method Not Allowed",
+            413 => "Payload Too Large",
             404 => "Not Found",
             500 => "Internal Server Error",
             _ => "Unknown",
@@ -438,6 +440,8 @@ impl Connection {
             201 => "Created",
             204 => "No Content",
             400 => "Bad Request",
+            405 => "Method Not Allowed",
+            413 => "Payload Too Large",
             404 => "Not Found",
             500 => "Internal Server Error",
             _ => "Unknown",

--- a/rover-server/src/lib.rs
+++ b/rover-server/src/lib.rs
@@ -32,10 +32,12 @@ pub type Bytes = bytes::Bytes;
 #[repr(u8)]
 pub enum HttpMethod {
     Get = 1,
-    Post = 2,
-    Put = 4,
-    Patch = 8,
-    Delete = 16,
+    Head = 2,
+    Options = 3,
+    Post = 4,
+    Put = 5,
+    Patch = 6,
+    Delete = 7,
 }
 
 impl HttpMethod {
@@ -54,6 +56,15 @@ impl HttpMethod {
             4 => {
                 if bytes.eq_ignore_ascii_case(b"post") {
                     Some(Self::Post)
+                } else if bytes.eq_ignore_ascii_case(b"head") {
+                    Some(Self::Head)
+                } else {
+                    None
+                }
+            }
+            7 => {
+                if bytes.eq_ignore_ascii_case(b"options") {
+                    Some(Self::Options)
                 } else {
                     None
                 }
@@ -79,6 +90,8 @@ impl HttpMethod {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Get => "GET",
+            Self::Head => "HEAD",
+            Self::Options => "OPTIONS",
             Self::Post => "POST",
             Self::Put => "PUT",
             Self::Patch => "PATCH",
@@ -87,7 +100,7 @@ impl HttpMethod {
     }
 
     pub fn valid_methods() -> &'static [&'static str] {
-        &["get", "post", "put", "patch", "delete"]
+        &["get", "head", "options", "post", "put", "patch", "delete"]
     }
 }
 


### PR DESCRIPTION
## Depends on
- #38

## Summary
Improves HTTP routing semantics with standards-compliant method handling and deterministic behavior for missing/unsupported methods.

## What changed
- Adds `HEAD` and `OPTIONS` method parsing
- Auto `HEAD` fallback to `GET` handler when `HEAD` is not explicitly defined
- Returns `405 Method Not Allowed` with `Allow` header when path exists but method is unsupported
- Auto `OPTIONS` response (`204 No Content`) with `Allow` header when path exists
- Keeps `404` for unknown paths
- Adds duplicate route warnings at startup (`last one wins`)

## Lua example
```lua
local api = rover.server {}

function api.echo.get(ctx)
  return api.json { method = "GET", ok = true }
end

function api.echo.post(ctx)
  return api.json:status(201, { method = "POST", ok = true })
end

return api
```

## Behavior examples
```bash
# Unsupported method on known path
curl -i -X PATCH http://localhost:4242/echo
# HTTP/1.1 405 Method Not Allowed
# Allow: GET, HEAD, POST, OPTIONS

# Auto OPTIONS on known path
curl -i -X OPTIONS http://localhost:4242/echo
# HTTP/1.1 204 No Content
# Allow: GET, HEAD, POST, OPTIONS

# Auto HEAD fallback to GET
curl -I http://localhost:4242/echo
# HTTP/1.1 200 OK
```

## Tests
- Added `fast_router` tests:
  - auto `HEAD` fallback
  - `405` with proper `Allow` methods
- Manual integration checks with `curl` for `405`, `OPTIONS`, and `HEAD`
- Updated docs in `docs/docs/api-reference/route-patterns.md`