### PR TITLE
input-validation: add 415/406 content negotiation handling

### DIFF
--- a/docs/docs/guides/context-api.md
+++ b/docs/docs/guides/context-api.md
@@ -96,6 +96,11 @@ end
 - `:bytes()` - body as byte table
 - `:expect(schema)` - validate with `rover.guard`
 
+Content negotiation behavior:
+
+- Calling `ctx:body():json()` or `ctx:body():expect(...)` requires `Content-Type: application/json` (or `+json`); otherwise Rover returns `415 Unsupported Media Type`.
+- If the request `Accept` header does not allow the response media type, Rover returns `406 Not Acceptable`.
+
 Example validation:
 
 ```lua

--- a/examples/input_validation.lua
+++ b/examples/input_validation.lua
@@ -1,0 +1,27 @@
+local api = rover.server {}
+
+function api.users.post(ctx)
+  local user = ctx:body():expect {
+    name = rover.guard:string():required(),
+    email = rover.guard:string():required(),
+  }
+
+  return api.json:status(201, {
+    ok = true,
+    user = user,
+  })
+end
+
+function api.search.get(ctx)
+  local q = ctx:query()
+  if not q.term then
+    return api.json:status(400, { error = "term is required" })
+  end
+
+  return api.json {
+    term = q.term,
+    page = tonumber(q.page or "1"),
+  }
+end
+
+return api

--- a/rover-server/src/connection.rs
+++ b/rover-server/src/connection.rs
@@ -1,5 +1,5 @@
-use crate::Bytes;
 use crate::ws_frame;
+use crate::Bytes;
 use bytes::BytesMut;
 use mio::net::TcpStream;
 use mio::{Interest, Registry, Token};
@@ -381,7 +381,9 @@ impl Connection {
             204 => "No Content",
             400 => "Bad Request",
             405 => "Method Not Allowed",
+            406 => "Not Acceptable",
             413 => "Payload Too Large",
+            415 => "Unsupported Media Type",
             404 => "Not Found",
             500 => "Internal Server Error",
             _ => "Unknown",
@@ -441,7 +443,9 @@ impl Connection {
             204 => "No Content",
             400 => "Bad Request",
             405 => "Method Not Allowed",
+            406 => "Not Acceptable",
             413 => "Payload Too Large",
+            415 => "Unsupported Media Type",
             404 => "Not Found",
             500 => "Internal Server Error",
             _ => "Unknown",

--- a/rover-server/src/event_loop.rs
+++ b/rover-server/src/event_loop.rs
@@ -710,7 +710,13 @@ impl EventLoop {
 
                 if let (Some(accept), Some(ct)) = (accept_header.as_deref(), content_type) {
                     if status < 400 && !Self::accepts_content_type(accept, ct) {
-                        conn.set_response_with_buf(406, b"Not Acceptable", Some("text/plain"), buf);
+                        let resp_buf = self.buffer_pool.get_response_buf();
+                        conn.set_response_with_buf(
+                            406,
+                            b"Not Acceptable",
+                            Some("text/plain"),
+                            resp_buf,
+                        );
                         let _ = conn.reregister(&self.poll.registry(), Interest::WRITABLE);
                         return Ok(());
                     }


### PR DESCRIPTION
## Depends on
- #39

## Summary
Adds stricter input/content handling for Phase 1: JSON body validation now enforces media type (415), and response negotiation now enforces `Accept` compatibility (406).

## Changes
- `ctx:body():json()` and `ctx:body():expect(...)` now require JSON media type:
  - accepts `application/json` and `*+json`
  - otherwise returns `415 Unsupported Media Type`
- Response negotiation in event loop:
  - if request `Accept` does not allow response `Content-Type`, returns `406 Not Acceptable`
- Added status text mapping for `406` and `415`
- Added unit tests for:
  - media type checks
  - accept matching behavior
- Added docs and example

## Lua example
```lua
local api = rover.server {}

function api.users.post(ctx)
  local user = ctx:body():expect {
    name = rover.guard:string():required(),
    email = rover.guard:string():required(),
  }

  return api.json:status(201, { ok = true, user = user })
end

return api
```

## Behavior checks
```bash
# 415 unsupported media type
curl -i -X POST http://localhost:4242/users \
  -H 'Content-Type: text/plain' \
  -d '{"name":"a","email":"a@a.com"}'

# 406 not acceptable
curl -i 'http://localhost:4242/search?term=abc' \
  -H 'Accept: text/plain'
```

## Files
- `rover-server/src/http_task.rs`
- `rover-server/src/event_loop.rs`
- `rover-server/src/connection.rs`
- `docs/docs/guides/context-api.md`
- `examples/input_validation.lua`