### PR TITLE
cors-support: configurable CORS + preflight + response headers

### DIFF
--- a/docs/docs/api-reference/configuration.md
+++ b/docs/docs/api-reference/configuration.md
@@ -15,7 +15,11 @@ local api = rover.server {
     host = "127.0.0.1",       -- default: "localhost"
     port = 3000,              -- default: 4242
     log_level = "debug",     -- default: "debug" ("debug" | "info" | "warn" | "error" | "nope")
-    docs = true               -- default: true (enable OpenAPI docs)
+    docs = true,              -- default: true (enable OpenAPI docs)
+    cors_origin = "*",       -- optional
+    cors_methods = "GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD",
+    cors_headers = "Content-Type, Authorization",
+    cors_credentials = false
 }
 
 function api.hello.get(ctx)
@@ -84,6 +88,30 @@ rover.server {
     docs = false  -- Disable docs endpoint
 }
 ```
+
+### `cors_origin`
+
+- **Type**: `string`
+- **Default**: `nil` (CORS disabled)
+- **Description**: Allowed CORS origin, e.g. `"*"` or `"https://app.example.com"`
+
+### `cors_methods`
+
+- **Type**: `string`
+- **Default**: `"GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD"`
+- **Description**: Value for `Access-Control-Allow-Methods`
+
+### `cors_headers`
+
+- **Type**: `string`
+- **Default**: `"Content-Type, Authorization"`
+- **Description**: Value for `Access-Control-Allow-Headers`
+
+### `cors_credentials`
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **Description**: Sets `Access-Control-Allow-Credentials: true` when enabled
 
 ## Complete Example
 

--- a/examples/cors_support.lua
+++ b/examples/cors_support.lua
@@ -1,0 +1,22 @@
+local api = rover.server {
+  cors_origin = "*",
+  cors_methods = "GET, POST, OPTIONS",
+  cors_headers = "Content-Type, Authorization",
+  cors_credentials = false,
+}
+
+function api.users.get(ctx)
+  return api.json {
+    users = { "alice", "bob" },
+  }
+end
+
+function api.users.post(ctx)
+  local body = ctx:body():json()
+  return api.json:status(201, {
+    created = true,
+    user = body,
+  })
+end
+
+return api

--- a/rover-server/src/connection.rs
+++ b/rover-server/src/connection.rs
@@ -470,14 +470,12 @@ impl Connection {
         )
         .unwrap();
 
-        // Add custom headers if provided
         if let Some(headers) = custom_headers {
             for (name, value) in headers {
                 write!(self.write_buf, "\r\n{}: {}", name, value).unwrap();
             }
         }
 
-        // End headers
         write!(self.write_buf, "\r\n\r\n").unwrap();
 
         // Store body directly (true zero-copy - no slice copy)

--- a/rover-server/src/lib.rs
+++ b/rover-server/src/lib.rs
@@ -162,6 +162,10 @@ pub struct ServerConfig {
     pub docs: bool,
     /// Maximum body size in bytes (None = no limit)
     pub body_size_limit: Option<usize>,
+    pub cors_origin: Option<String>,
+    pub cors_methods: String,
+    pub cors_headers: String,
+    pub cors_credentials: bool,
 }
 
 impl FromLua for ServerConfig {
@@ -201,6 +205,26 @@ impl FromLua for ServerConfig {
                         _ => true,
                     },
                     body_size_limit,
+                    cors_origin: match config.get::<Value>("cors_origin")? {
+                        Value::Nil => None,
+                        Value::String(s) => Some(s.to_str()?.to_string()),
+                        _ => None,
+                    },
+                    cors_methods: match config.get::<Value>("cors_methods")? {
+                        Value::Nil => "GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD".to_string(),
+                        Value::String(s) => s.to_str()?.to_string(),
+                        _ => "GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD".to_string(),
+                    },
+                    cors_headers: match config.get::<Value>("cors_headers")? {
+                        Value::Nil => "Content-Type, Authorization".to_string(),
+                        Value::String(s) => s.to_str()?.to_string(),
+                        _ => "Content-Type, Authorization".to_string(),
+                    },
+                    cors_credentials: match config.get::<Value>("cors_credentials")? {
+                        Value::Nil => false,
+                        Value::Boolean(b) => b,
+                        _ => false,
+                    },
                 })
             }
             _ => Err(anyhow!("Server config must be a table"))?,


### PR DESCRIPTION
## Depends on
- #40

## Why
Browsers need CORS headers + preflight handling for cross-origin API calls.

## What changed
- Added server config fields in `rover.server`:
  - `cors_origin` (optional; `nil` disables CORS)
  - `cors_methods` (default: `GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD`)
  - `cors_headers` (default: `Content-Type, Authorization`)
  - `cors_credentials` (default: `false`)
- Added preflight handling in event loop:
  - On `OPTIONS` with `Origin` + `Access-Control-Request-Method`, returns `204` with CORS headers.
- Added CORS headers on normal responses when request has `Origin` and CORS is enabled.
- Extended response writer to support custom headers (`set_response_bytes_with_headers`).
- Added/updated docs and example:
  - `docs/docs/api-reference/configuration.md`
  - `examples/cors_support.lua`

## Notes
- If `cors_origin = "*"`, response uses `*`; else server reflects request `Origin`.
- `Access-Control-Allow-Credentials` is included only when `cors_credentials = true`.
- This diff also adds missing HTTP reason phrases used elsewhere (`405`, `406`, `413`, `415`) in the connection writer.

## Verify
```bash
# preflight
curl -i -X OPTIONS http://localhost:4242/users \
  -H 'Origin: https://app.example.com' \
  -H 'Access-Control-Request-Method: POST'

# actual request
curl -i http://localhost:4242/users \
  -H 'Origin: https://app.example.com'
```