### PR TITLE
Harden coroutine resume mapping + replace wrk benchmark with Rust perf harness

### DIFF
--- a/rover-cli/tests/perf_http_echo.rs
+++ b/rover-cli/tests/perf_http_echo.rs
@@ -1,0 +1,282 @@
+use std::env;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const HOST: &str = "127.0.0.1";
+const PORT: u16 = 3000;
+
+struct ServerGuard {
+    child: Child,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[derive(Default)]
+struct WorkerResult {
+    latencies_us: Vec<u64>,
+    errors: usize,
+}
+
+fn parse_usize_env(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn parse_u64_env(name: &str, default: u64) -> u64 {
+    env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+fn percentile_us(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let rank = ((p / 100.0) * (sorted.len().saturating_sub(1) as f64)).round() as usize;
+    sorted[rank.min(sorted.len() - 1)]
+}
+
+fn perf_script_path() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.join("../tests/perf/main.lua")
+}
+
+fn start_server() -> ServerGuard {
+    let rover_bin = env!("CARGO_BIN_EXE_rover");
+    let script = perf_script_path();
+
+    let child = Command::new(rover_bin)
+        .arg("run")
+        .arg(script)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rover server");
+
+    ServerGuard { child }
+}
+
+fn send_one_request(stream: &mut TcpStream, req: &[u8], buf: &mut Vec<u8>) -> std::io::Result<u16> {
+    stream.write_all(req)?;
+
+    buf.clear();
+    let mut headers_end = None;
+
+    while headers_end.is_none() {
+        let mut tmp = [0u8; 2048];
+        let n = stream.read(&mut tmp)?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "connection closed while reading headers",
+            ));
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if let Some(pos) = find_headers_end(buf) {
+            headers_end = Some(pos);
+        }
+    }
+
+    let headers_end = headers_end.expect("headers_end set");
+    let status = parse_status_code(buf).unwrap_or(0);
+    let content_len = parse_content_length(&buf[..headers_end]).unwrap_or(0);
+
+    let body_in_buf = buf.len().saturating_sub(headers_end);
+    if body_in_buf < content_len {
+        let to_read = content_len - body_in_buf;
+        let mut remaining = vec![0u8; to_read];
+        stream.read_exact(&mut remaining)?;
+    }
+
+    Ok(status)
+}
+
+fn find_headers_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|i| i + 4)
+}
+
+fn parse_status_code(buf: &[u8]) -> Option<u16> {
+    let line_end = buf.windows(2).position(|w| w == b"\r\n")?;
+    let line = std::str::from_utf8(&buf[..line_end]).ok()?;
+    let mut parts = line.split_whitespace();
+    let _http = parts.next()?;
+    parts.next()?.parse::<u16>().ok()
+}
+
+fn parse_content_length(headers: &[u8]) -> Option<usize> {
+    let s = std::str::from_utf8(headers).ok()?;
+    s.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        if name.trim().eq_ignore_ascii_case("content-length") {
+            value.trim().parse::<usize>().ok()
+        } else {
+            None
+        }
+    })
+}
+
+fn wait_until_ready(timeout: Duration) {
+    let start = Instant::now();
+    let req = b"GET /echo HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+
+    loop {
+        if start.elapsed() > timeout {
+            panic!("server did not become ready in {:?}", timeout);
+        }
+
+        if let Ok(mut stream) = TcpStream::connect((HOST, PORT)) {
+            let mut buf = Vec::with_capacity(4096);
+            if let Ok(status) = send_one_request(&mut stream, req, &mut buf) {
+                if status == 200 {
+                    return;
+                }
+            }
+        }
+
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn run_load(threads: usize, requests_per_thread: usize) -> (Vec<u64>, usize, Duration) {
+    let start_barrier = Arc::new(Barrier::new(threads));
+    let req = b"GET /echo HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n".to_vec();
+
+    let start = Instant::now();
+
+    let handles: Vec<_> = (0..threads)
+        .map(|_| {
+            let start_barrier = Arc::clone(&start_barrier);
+            let req = req.clone();
+
+            thread::spawn(move || {
+                let mut result = WorkerResult {
+                    latencies_us: Vec::with_capacity(requests_per_thread),
+                    errors: 0,
+                };
+
+                let mut stream = match TcpStream::connect((HOST, PORT)) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        result.errors = requests_per_thread;
+                        return result;
+                    }
+                };
+                let _ = stream.set_nodelay(true);
+
+                let mut buf = Vec::with_capacity(8192);
+
+                start_barrier.wait();
+
+                for _ in 0..requests_per_thread {
+                    let t0 = Instant::now();
+                    match send_one_request(&mut stream, &req, &mut buf) {
+                        Ok(200) => {
+                            result.latencies_us.push(t0.elapsed().as_micros() as u64);
+                        }
+                        Ok(_) => {
+                            result.errors += 1;
+                        }
+                        Err(_) => {
+                            result.errors += 1;
+                            match TcpStream::connect((HOST, PORT)) {
+                                Ok(new_stream) => {
+                                    stream = new_stream;
+                                    let _ = stream.set_nodelay(true);
+                                }
+                                Err(_) => {
+                                    let remaining = requests_per_thread
+                                        .saturating_sub(result.latencies_us.len() + result.errors);
+                                    result.errors += remaining;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                result
+            })
+        })
+        .collect();
+
+    let mut all_latencies = Vec::with_capacity(threads * requests_per_thread);
+    let mut total_errors = 0usize;
+
+    for handle in handles {
+        let worker = handle.join().expect("worker thread");
+        total_errors += worker.errors;
+        all_latencies.extend(worker.latencies_us);
+    }
+
+    let duration = start.elapsed();
+    (all_latencies, total_errors, duration)
+}
+
+#[test]
+#[ignore = "performance test; run explicitly"]
+fn perf_http_echo_regression() {
+    let _server = start_server();
+    wait_until_ready(Duration::from_secs(10));
+
+    let threads = parse_usize_env("ROVER_PERF_THREADS", 8);
+    let req_per_thread = parse_usize_env("ROVER_PERF_REQUESTS_PER_THREAD", 2000);
+    let min_rps = parse_u64_env("ROVER_PERF_MIN_RPS", 20_000);
+    let max_p99_ms = parse_u64_env("ROVER_PERF_MAX_P99_MS", 15);
+
+    let (mut latencies, errors, duration) = run_load(threads, req_per_thread);
+    latencies.sort_unstable();
+
+    let total = (threads * req_per_thread) as u64;
+    let ok = (total as usize).saturating_sub(errors) as u64;
+    let rps = if duration.as_secs_f64() > 0.0 {
+        (ok as f64 / duration.as_secs_f64()) as u64
+    } else {
+        0
+    };
+
+    let mean_us = if !latencies.is_empty() {
+        latencies.iter().copied().sum::<u64>() / (latencies.len() as u64)
+    } else {
+        0
+    };
+    let p50_us = percentile_us(&latencies, 50.0);
+    let p95_us = percentile_us(&latencies, 95.0);
+    let p99_us = percentile_us(&latencies, 99.0);
+
+    println!(
+        "perf: total={} ok={} errors={} threads={} req_per_thread={} duration_ms={} rps={} mean_us={} p50_us={} p95_us={} p99_us={}",
+        total,
+        ok,
+        errors,
+        threads,
+        req_per_thread,
+        duration.as_millis(),
+        rps,
+        mean_us,
+        p50_us,
+        p95_us,
+        p99_us
+    );
+
+    assert_eq!(errors, 0, "non-200 or network errors detected");
+    assert!(rps >= min_rps, "rps={} below min_rps={}", rps, min_rps);
+    assert!(
+        p99_us <= max_p99_ms * 1000,
+        "p99_ms={} above max_p99_ms={}",
+        p99_us as f64 / 1000.0,
+        max_p99_ms
+    );
+}

--- a/rover-server/src/event_loop.rs
+++ b/rover-server/src/event_loop.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::io;
 use std::mem;
 use std::net::SocketAddr;
@@ -11,9 +12,9 @@ use anyhow::Result;
 use mio::net::TcpListener;
 use mio::{Events, Interest, Poll, Token};
 use mlua::{Function, Lua, RegistryKey, Thread, ThreadStatus, Value};
-use rover_ui::coroutine::{run_coroutine_with_delay, CoroutineResult};
-use rover_ui::scheduler::SharedScheduler;
 use rover_ui::SharedSignalRuntime;
+use rover_ui::coroutine::{CoroutineResult, run_coroutine_with_delay};
+use rover_ui::scheduler::SharedScheduler;
 use slab::Slab;
 use tracing::{debug, info, warn};
 
@@ -21,7 +22,7 @@ use crate::buffer_pool::BufferPool;
 use crate::connection::{Connection, ConnectionState};
 use crate::fast_router::{FastRouter, RouteMatch};
 use crate::http_task::{
-    execute_handler_coroutine, CoroutineResponse, RequestContextPool, ThreadPool,
+    CoroutineResponse, RequestContextPool, ThreadPool, execute_handler_coroutine,
 };
 use crate::table_pool::LuaTablePool;
 use crate::ws_frame::{self, WsOpcode};
@@ -39,9 +40,52 @@ struct PendingCoroutine {
     ctx_idx: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct ConnKey {
+    slot: usize,
+    generation: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ReadyEvent {
+    token: Token,
+    readable: bool,
+    writable: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::EventLoop;
+    use crate::ServerConfig;
+    use mlua::Lua;
+    use std::net::{SocketAddr, TcpStream};
+
+    fn test_server_config() -> ServerConfig {
+        ServerConfig {
+            port: 0,
+            host: "127.0.0.1".to_string(),
+            log_level: "nope".to_string(),
+            docs: false,
+            body_size_limit: None,
+            cors_origin: None,
+            cors_methods: "GET".to_string(),
+            cors_headers: "Content-Type".to_string(),
+            cors_credentials: false,
+        }
+    }
+
+    fn test_event_loop() -> EventLoop {
+        EventLoop::new(
+            Lua::new(),
+            Vec::new(),
+            Vec::new(),
+            test_server_config(),
+            None,
+            SocketAddr::from(([127, 0, 0, 1], 0)),
+            None,
+        )
+        .expect("event loop")
+    }
 
     #[test]
     fn should_accept_wildcard_accept_header() {
@@ -71,6 +115,28 @@ mod tests {
             "application/json"
         ));
     }
+
+    #[test]
+    fn should_invalidate_old_conn_generation_after_slot_reuse() {
+        let mut event_loop = test_event_loop();
+        let addr = event_loop.listener.local_addr().expect("listener addr");
+
+        let _client_1 = TcpStream::connect(addr).expect("connect #1");
+        event_loop.accept_connections().expect("accept #1");
+
+        let first_key = event_loop.conn_key(0).expect("first conn key");
+        assert!(event_loop.is_conn_key_active(first_key));
+
+        event_loop.remove_connection(0);
+
+        let _client_2 = TcpStream::connect(addr).expect("connect #2");
+        event_loop.accept_connections().expect("accept #2");
+
+        let second_key = event_loop.conn_key(0).expect("second conn key");
+        assert_ne!(first_key.generation, second_key.generation);
+        assert!(!event_loop.is_conn_key_active(first_key));
+        assert!(event_loop.is_conn_key_active(second_key));
+    }
 }
 
 pub struct EventLoop {
@@ -81,7 +147,9 @@ pub struct EventLoop {
     router: FastRouter,
     config: ServerConfig,
     openapi_spec: Option<serde_json::Value>,
-    yielded_coroutines: HashMap<usize, PendingCoroutine>,
+    yielded_coroutines: HashMap<ConnKey, PendingCoroutine>,
+    conn_generations: Vec<u64>,
+    ready_queue: VecDeque<ReadyEvent>,
     thread_pool: ThreadPool,
     request_pool: RequestContextPool,
     table_pool: LuaTablePool,
@@ -201,6 +269,8 @@ impl EventLoop {
             config,
             openapi_spec,
             yielded_coroutines: HashMap::with_capacity(1024),
+            conn_generations: vec![0; 1024],
+            ready_queue: VecDeque::with_capacity(2048),
             thread_pool: ThreadPool::new(2048),
             request_pool,
             table_pool,
@@ -218,9 +288,17 @@ impl EventLoop {
             self.poll.poll(&mut events, poll_timeout)?;
 
             for event in events.iter() {
-                match event.token() {
+                self.ready_queue.push_back(ReadyEvent {
+                    token: event.token(),
+                    readable: event.is_readable(),
+                    writable: event.is_writable(),
+                });
+            }
+
+            while let Some(ready) = self.ready_queue.pop_front() {
+                match ready.token {
                     LISTENER => self.accept_connections()?,
-                    token => self.handle_connection(token, event)?,
+                    token => self.handle_connection(token, ready.readable, ready.writable)?,
                 }
             }
 
@@ -303,15 +381,23 @@ impl EventLoop {
         loop {
             match self.listener.accept() {
                 Ok((mut socket, _addr)) => {
-                    let mut conns = self.connections.borrow_mut();
-                    let entry = conns.vacant_entry();
-                    let token = Token(entry.key() + 1);
+                    let conn_idx = {
+                        let conns = self.connections.borrow();
+                        conns.vacant_key()
+                    };
+                    let token = Token(conn_idx + 1);
+                    let generation = self.bump_conn_generation(conn_idx);
 
                     self.poll
                         .registry()
                         .register(&mut socket, token, Interest::READABLE)?;
 
-                    entry.insert(Connection::new(socket, token));
+                    let mut conns = self.connections.borrow_mut();
+                    conns.insert(Connection::new(socket, token));
+
+                    if self.config.log_level == "debug" {
+                        debug!("accepted conn slot={} gen={}", conn_idx, generation);
+                    }
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                     break;
@@ -322,7 +408,7 @@ impl EventLoop {
         Ok(())
     }
 
-    fn handle_connection(&mut self, token: Token, event: &mio::event::Event) -> Result<()> {
+    fn handle_connection(&mut self, token: Token, readable: bool, writable: bool) -> Result<()> {
         let conn_idx = token.0 - 1;
 
         if !self.connections.borrow().contains(conn_idx) {
@@ -335,7 +421,7 @@ impl EventLoop {
             if let Some(conn) = conns.get(conn_idx) {
                 if conn.is_websocket() {
                     drop(conns);
-                    return self.handle_ws_event(conn_idx, event);
+                    return self.handle_ws_event(conn_idx, readable, writable);
                 }
             }
         }
@@ -345,7 +431,7 @@ impl EventLoop {
             let conn = &mut conns[conn_idx];
 
             match conn.state {
-                ConnectionState::Reading if event.is_readable() => match conn.try_read() {
+                ConnectionState::Reading if readable => match conn.try_read() {
                     Ok(true) => (true, false, false, false),
                     Ok(false) => (false, false, false, false),
                     Err(_) => {
@@ -353,7 +439,7 @@ impl EventLoop {
                         (false, true, false, false)
                     }
                 },
-                ConnectionState::Writing if event.is_writable() => match conn.try_write() {
+                ConnectionState::Writing if writable => match conn.try_write() {
                     Ok(true) => {
                         // Check if this was a WS upgrade 101 response
                         if conn.pending_ws_upgrade.is_some() {
@@ -389,10 +475,7 @@ impl EventLoop {
         };
 
         if should_close || is_closed_state {
-            self.recycle_write_buf(conn_idx);
-            let mut conns = self.connections.borrow_mut();
-            let mut conn = conns.remove(conn_idx);
-            let _ = self.poll.registry().deregister(&mut conn.socket);
+            self.remove_connection(conn_idx);
             return Ok(());
         }
 
@@ -808,14 +891,21 @@ impl EventLoop {
                 let mut conns = self.connections.borrow_mut();
                 let conn = &mut conns[conn_idx];
                 conn.thread = Some(thread.clone());
-                self.yielded_coroutines.insert(
-                    conn_idx,
-                    PendingCoroutine {
-                        thread,
-                        started_at: Instant::now(),
-                        ctx_idx,
-                    },
-                );
+                drop(conns);
+
+                if let Some(conn_key) = self.conn_key(conn_idx) {
+                    self.yielded_coroutines.insert(
+                        conn_key,
+                        PendingCoroutine {
+                            thread,
+                            started_at: Instant::now(),
+                            ctx_idx,
+                        },
+                    );
+                } else {
+                    self.thread_pool.release(thread);
+                    self.request_pool.release(ctx_idx);
+                }
             }
             Err(_) => {
                 let mut conns = self.connections.borrow_mut();
@@ -1093,12 +1183,12 @@ impl EventLoop {
 
     // ── WebSocket event handling ──
 
-    fn handle_ws_event(&mut self, conn_idx: usize, event: &mio::event::Event) -> Result<()> {
-        if event.is_readable() {
+    fn handle_ws_event(&mut self, conn_idx: usize, readable: bool, writable: bool) -> Result<()> {
+        if readable {
             self.handle_ws_readable(conn_idx)?;
         }
 
-        if event.is_writable() {
+        if writable {
             self.handle_ws_writable(conn_idx)?;
         }
 
@@ -1536,13 +1626,7 @@ impl EventLoop {
         }
 
         // Deregister and remove connection
-        {
-            let mut conns = self.connections.borrow_mut();
-            if conns.contains(conn_idx) {
-                let mut conn = conns.remove(conn_idx);
-                let _ = self.poll.registry().deregister(&mut conn.socket);
-            }
-        }
+        self.remove_connection(conn_idx);
 
         info!(
             "WS connection {} disconnected from endpoint #{}",
@@ -1555,8 +1639,15 @@ impl EventLoop {
 
     fn check_timeouts(&mut self) -> Result<()> {
         let mut to_timeout = Vec::new();
+        let mut stale_keys = Vec::new();
 
-        for (&conn_idx, pending) in self.yielded_coroutines.iter() {
+        for (&conn_key, pending) in self.yielded_coroutines.iter() {
+            if !self.is_conn_key_active(conn_key) {
+                stale_keys.push(conn_key);
+                continue;
+            }
+
+            let conn_idx = conn_key.slot;
             // Skip WS connections -- they're long-lived
             {
                 let conns = self.connections.borrow();
@@ -1569,12 +1660,17 @@ impl EventLoop {
                 }
             }
             if pending.started_at.elapsed().as_millis() as u64 > DEFAULT_COROUTINE_TIMEOUT_MS {
-                to_timeout.push(conn_idx);
+                to_timeout.push(conn_key);
             }
         }
 
-        for conn_idx in to_timeout {
-            self.yielded_coroutines.remove(&conn_idx);
+        for conn_key in stale_keys {
+            self.cleanup_pending_coroutine(conn_key);
+        }
+
+        for conn_key in to_timeout {
+            self.cleanup_pending_coroutine(conn_key);
+            let conn_idx = conn_key.slot;
             let mut conns = self.connections.borrow_mut();
             if !conns.contains(conn_idx) {
                 continue;
@@ -1621,23 +1717,26 @@ impl EventLoop {
 
     fn resume_yielded_coroutines(&mut self) -> Result<()> {
         let mut to_resume = Vec::new();
+        let mut stale_keys = Vec::new();
 
-        for (&conn_idx, pending) in self.yielded_coroutines.iter() {
-            if !self.connections.borrow().contains(conn_idx) {
-                to_resume.push(conn_idx);
+        for (&conn_key, pending) in self.yielded_coroutines.iter() {
+            if !self.is_conn_key_active(conn_key) {
+                stale_keys.push(conn_key);
                 continue;
             }
 
-            match pending.thread.status() {
-                ThreadStatus::Resumable => {
-                    to_resume.push(conn_idx);
-                }
-                _ => {}
+            if pending.thread.status() == ThreadStatus::Resumable {
+                to_resume.push(conn_key);
             }
         }
 
-        for conn_idx in to_resume {
-            if let Some(pending) = self.yielded_coroutines.remove(&conn_idx) {
+        for conn_key in stale_keys {
+            self.cleanup_pending_coroutine(conn_key);
+        }
+
+        for conn_key in to_resume {
+            let conn_idx = conn_key.slot;
+            if let Some(pending) = self.yielded_coroutines.remove(&conn_key) {
                 match pending.thread.resume(()) {
                     Ok(mlua::Value::Nil) => {
                         self.thread_pool.release(pending.thread);
@@ -1670,5 +1769,78 @@ impl EventLoop {
         }
 
         Ok(())
+    }
+
+    #[inline]
+    fn bump_conn_generation(&mut self, conn_idx: usize) -> u64 {
+        if conn_idx >= self.conn_generations.len() {
+            self.conn_generations.resize(conn_idx + 1, 0);
+        }
+        let next = self.conn_generations[conn_idx].wrapping_add(1).max(1);
+        self.conn_generations[conn_idx] = next;
+        next
+    }
+
+    #[inline]
+    fn conn_key(&self, conn_idx: usize) -> Option<ConnKey> {
+        if !self.connections.borrow().contains(conn_idx) {
+            return None;
+        }
+        let generation = *self.conn_generations.get(conn_idx)?;
+        if generation == 0 {
+            return None;
+        }
+        Some(ConnKey {
+            slot: conn_idx,
+            generation,
+        })
+    }
+
+    #[inline]
+    fn is_conn_key_active(&self, conn_key: ConnKey) -> bool {
+        if !self.connections.borrow().contains(conn_key.slot) {
+            return false;
+        }
+        self.conn_generations
+            .get(conn_key.slot)
+            .copied()
+            .unwrap_or_default()
+            == conn_key.generation
+    }
+
+    fn cleanup_pending_coroutine(&mut self, conn_key: ConnKey) {
+        if let Some(pending) = self.yielded_coroutines.remove(&conn_key) {
+            self.thread_pool.release(pending.thread);
+            self.request_pool.release(pending.ctx_idx);
+        }
+    }
+
+    fn remove_connection(&mut self, conn_idx: usize) {
+        self.recycle_write_buf(conn_idx);
+
+        if let Some(generation) = self.conn_generations.get(conn_idx).copied() {
+            if generation != 0 {
+                self.cleanup_pending_coroutine(ConnKey {
+                    slot: conn_idx,
+                    generation,
+                });
+            }
+        }
+
+        let stale_keys: Vec<ConnKey> = self
+            .yielded_coroutines
+            .keys()
+            .copied()
+            .filter(|k| k.slot == conn_idx)
+            .collect();
+        for key in stale_keys {
+            self.cleanup_pending_coroutine(key);
+        }
+
+        let mut conns = self.connections.borrow_mut();
+        if conns.contains(conn_idx) {
+            let mut conn = conns.remove(conn_idx);
+            let _ = self.poll.registry().deregister(&mut conn.socket);
+        }
     }
 }

--- a/rover-server/tests/ws_handshake_integration.rs
+++ b/rover-server/tests/ws_handshake_integration.rs
@@ -1,0 +1,22 @@
+use rover_server::ws_handshake::{compute_accept_key, validate_upgrade_headers};
+
+#[test]
+fn should_validate_upgrade_headers_with_mixed_case_connection_tokens() {
+    let raw = b"GET /ws HTTP/1.1\r\nUPGRADE: websocket\r\nConnection: keep-alive, UpGrAdE\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+
+    let headers = vec![
+        (18, 7, 27, 9),
+        (38, 10, 50, 19),
+        (71, 17, 90, 24),
+        (116, 21, 139, 2),
+    ];
+
+    let key = validate_upgrade_headers(raw, &headers).expect("valid ws upgrade headers");
+    assert_eq!(key, "dGhlIHNhbXBsZSBub25jZQ==");
+}
+
+#[test]
+fn should_keep_accept_hash_stable() {
+    let key = compute_accept_key("dGhlIHNhbXBsZSBub25jZQ==");
+    assert_eq!(key, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+}

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -1,6 +1,6 @@
 # Rover Performance Benchmarking Suite
 
-A comprehensive performance testing framework for Rover using `wrk` (HTTP benchmarking tool).
+Rust-native perf regression suite. No external `wrk` dependency.
 
 ## Quick Start
 
@@ -10,20 +10,32 @@ bash run_benchmark.sh
 ```
 
 This will:
-1. Build Rover in release mode
-2. Start an echo server on port 3000
-3. Run the benchmark with 2 threads, 100 connections, 30 seconds
-4. Display detailed performance metrics in an AI-friendly format
-5. Stop the server
+1. Build/test in release mode
+2. Spawn Rover server from Rust integration test
+3. Generate concurrent HTTP load from Rust worker threads
+4. Assert throughput and p99 thresholds
+5. Print metrics for tracking regressions
 
 ## Files
 
 - **main.lua** - Simple echo server with GET and POST `/echo` endpoints
-- **benchmark.lua** - wrk Lua script with detailed metrics collection
-- **test.sh** - Basic wrk command (2 threads, 100 connections, 30s)
-- **run_benchmark.sh** - Complete automated benchmark suite
+- **benchmark.lua** - Legacy wrk script (kept for reference)
+- **test.sh** - Runs Rust perf integration test (`cargo test --release ...`)
+- **run_benchmark.sh** - Wrapper for full automated run
 - **track_metrics.sh** - Save results and compare with previous runs
 - **analyze.sh** - Performance analysis guide and bottleneck detection
+- **rover-cli/tests/perf_http_echo.rs** - Rust perf regression test harness
+
+## Environment knobs
+
+Use env vars to tune load/thresholds:
+
+```bash
+ROVER_PERF_THREADS=8
+ROVER_PERF_REQUESTS_PER_THREAD=2000
+ROVER_PERF_MIN_RPS=20000
+ROVER_PERF_MAX_P99_MS=15
+```
 
 ## Benchmark Metrics Explained
 

--- a/tests/perf/run_benchmark.sh
+++ b/tests/perf/run_benchmark.sh
@@ -1,87 +1,17 @@
 #!/bin/bash
-
-# Comprehensive performance benchmark suite for Rover
-# This script builds, runs the echo server, benchmarks it, and provides profiling insights
-
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-SERVER_PORT=3000
-SERVER_PID=""
 
-# Colors for output
-RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-cleanup() {
-    if [ -n "$SERVER_PID" ]; then
-        echo -e "${YELLOW}Stopping server...${NC}"
-        kill $SERVER_PID 2>/dev/null || true
-        sleep 1
-    fi
-}
-
-trap cleanup EXIT
-
-echo -e "${GREEN}=== ROVER PERFORMANCE BENCHMARK SUITE ===${NC}"
+echo -e "${GREEN}=== ROVER RUST PERF SUITE ===${NC}"
 echo ""
-
-# Step 1: Build in release mode
-echo -e "${YELLOW}Step 1: Building Rover in release mode...${NC}"
+echo -e "${YELLOW}Running perf regression integration test (release)...${NC}"
 cd "$PROJECT_ROOT"
-cargo build --release
-echo -e "${GREEN}✓ Build complete${NC}"
+bash "$SCRIPT_DIR/test.sh"
 echo ""
-
-# Step 2: Start the server
-echo -e "${YELLOW}Step 2: Starting echo server on port $SERVER_PORT...${NC}"
-"$PROJECT_ROOT/target/release/rover" "$SCRIPT_DIR/main.lua" &
-SERVER_PID=$!
-sleep 2
-
-# Verify server is running
-if ! kill -0 $SERVER_PID 2>/dev/null; then
-    echo -e "${RED}✗ Failed to start server${NC}"
-    exit 1
-fi
-echo -e "${GREEN}✓ Server running (PID: $SERVER_PID)${NC}"
-echo ""
-
-# Step 3: Verify server is responding
-echo -e "${YELLOW}Step 3: Verifying server is responding...${NC}"
-if curl -s http://localhost:$SERVER_PORT/echo > /dev/null; then
-    echo -e "${GREEN}✓ Server responding to requests${NC}"
-else
-    echo -e "${RED}✗ Server not responding${NC}"
-    exit 1
-fi
-echo ""
-
-# Step 4: Run the benchmark
-echo -e "${YELLOW}Step 4: Running performance benchmark (2 threads, 100 connections, 30s)...${NC}"
-echo ""
-cd "$SCRIPT_DIR"
-bash test.sh
-BENCHMARK_RESULT=$?
-echo ""
-
-if [ $BENCHMARK_RESULT -eq 0 ]; then
-    echo -e "${GREEN}✓ Benchmark completed successfully${NC}"
-else
-    echo -e "${RED}✗ Benchmark failed${NC}"
-    exit 1
-fi
-
-echo ""
-echo -e "${GREEN}=== BENCHMARK COMPLETE ===${NC}"
-echo ""
-echo -e "${YELLOW}Next steps:${NC}"
-echo "  1. Review the latency metrics above - p99 latency indicates tail performance"
-echo "  2. Check if requests_per_sec is stable across multiple runs"
-echo "  3. Look for error spikes which indicate bottlenecks"
-echo "  4. To profile code hotspots, use: perf record -p \$PID"
-echo "  5. Compare multiple runs to identify performance regressions"
-echo ""
+echo -e "${GREEN}✓ Perf regression test passed${NC}"

--- a/tests/perf/test.sh
+++ b/tests/perf/test.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-# Performance benchmark test
-# -t2: 2 threads (2 CPUs)
-# -c100: 100 concurrent connections
-# -d30s: 30 second test duration
-# -s benchmark.lua: Use custom benchmark script for detailed metrics
+set -euo pipefail
 
-wrk -t2 -c100 -d30s -s benchmark.lua http://localhost:3000/echo
+# Rust-native perf regression test.
+# Override thresholds via env vars:
+#   ROVER_PERF_THREADS
+#   ROVER_PERF_REQUESTS_PER_THREAD
+#   ROVER_PERF_MIN_RPS
+#   ROVER_PERF_MAX_P99_MS
 
+cargo test --release -p rover_cli perf_http_echo_regression -- --ignored --nocapture

--- a/tests/perf/track_metrics.sh
+++ b/tests/perf/track_metrics.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Performance Metrics Tracker
 # Runs benchmark and saves results for comparison and regression detection
@@ -29,11 +30,14 @@ echo ""
 echo -e "${YELLOW}=== KEY METRICS ===${NC}"
 echo ""
 
-if grep -q "SUMMARY:" "$RESULT_FILE"; then
-    RPS=$(grep "requests_per_sec=" "$RESULT_FILE" | awk -F'=' '{print $2}')
-    ERRORS=$(grep "total_errors=" "$RESULT_FILE" | awk -F'=' '{print $2}')
-    P99=$(grep "p99=" "$RESULT_FILE" | grep "LATENCY_MS" -A 20 | grep "p99=" | head -1 | awk -F'=' '{print $2}')
-    MEAN=$(grep "mean=" "$RESULT_FILE" | grep "LATENCY_MS" -A 10 | head -1 | awk -F'=' '{print $2}')
+PERF_LINE=$(grep "perf: total=" "$RESULT_FILE" | tail -1 || true)
+if [ -n "$PERF_LINE" ]; then
+    RPS=$(echo "$PERF_LINE" | sed -E 's/.* rps=([0-9]+).*/\1/')
+    ERRORS=$(echo "$PERF_LINE" | sed -E 's/.* errors=([0-9]+).*/\1/')
+    MEAN_US=$(echo "$PERF_LINE" | sed -E 's/.* mean_us=([0-9]+).*/\1/')
+    P99_US=$(echo "$PERF_LINE" | sed -E 's/.* p99_us=([0-9]+).*/\1/')
+    MEAN=$(echo "scale=3; $MEAN_US/1000" | bc)
+    P99=$(echo "scale=3; $P99_US/1000" | bc)
 
     echo "Requests/sec:  $RPS"
     echo "Mean Latency:  ${MEAN} ms"
@@ -45,8 +49,10 @@ if grep -q "SUMMARY:" "$RESULT_FILE"; then
     PREV_FILE=$(ls -t "$RESULTS_DIR"/benchmark_*.txt 2>/dev/null | head -2 | tail -1)
     if [ -n "$PREV_FILE" ] && [ "$PREV_FILE" != "$RESULT_FILE" ]; then
         echo -e "${YELLOW}=== COMPARISON WITH PREVIOUS RUN ===${NC}"
-        PREV_RPS=$(grep "requests_per_sec=" "$PREV_FILE" | awk -F'=' '{print $2}')
-        PREV_P99=$(grep "p99=" "$PREV_FILE" | grep "LATENCY_MS" -A 20 | grep "p99=" | head -1 | awk -F'=' '{print $2}')
+        PREV_PERF_LINE=$(grep "perf: total=" "$PREV_FILE" | tail -1 || true)
+        PREV_RPS=$(echo "$PREV_PERF_LINE" | sed -E 's/.* rps=([0-9]+).*/\1/')
+        PREV_P99_US=$(echo "$PREV_PERF_LINE" | sed -E 's/.* p99_us=([0-9]+).*/\1/')
+        PREV_P99=$(echo "scale=3; $PREV_P99_US/1000" | bc)
 
         if [ -n "$PREV_RPS" ] && [ -n "$RPS" ]; then
             RPS_CHANGE=$(echo "scale=2; (($RPS - $PREV_RPS) / $PREV_RPS) * 100" | bc)


### PR DESCRIPTION
## Summary
- Fixes a critical event-loop correctness risk: yielded coroutines are now keyed by `ConnKey { slot, generation }` instead of raw `conn_idx`, preventing stale coroutine resume after slab slot/token reuse.
- Adds a separate ready queue for mio events (`VecDeque<ReadyEvent>`) so event capture and handling are decoupled and easier to control.
- Replaces the brittle shell/wrk benchmark flow with a Rust-native perf regression integration test (`rover-cli/tests/perf_http_echo.rs`) that spawns Rover, drives concurrent load, computes latency percentiles, and enforces thresholds.
- Updates perf scripts/docs to use the Rust harness by default, removing external wrk dependency from the primary benchmark workflow.
- Adds integration coverage for websocket handshake behavior (`rover-server/tests/ws_handshake_integration.rs`).

## Most Critical Change
- **Coroutine waiter key safety** (`rover-server/src/event_loop.rs`):
  - Before: `yielded_coroutines: HashMap<usize, PendingCoroutine>` keyed by connection index only.
  - Risk: when a connection closes and slab slot is reused, an old pending coroutine can be incorrectly resumed on a new connection occupying same slot.
  - After: `HashMap<ConnKey, PendingCoroutine>` where `ConnKey = {slot, generation}` and generation increments on each accept for that slot.
  - Also added centralized pending cleanup on connection removal and stale-key pruning in timeout/resume paths.

## Why This Matters
- Prevents silent cross-request corruption and wrong coroutine wakeups under churn/reconnect load.
- Makes perf regression testing deterministic, CI-friendly, and repository-local.
- Removes dependency on local wrk install and fragile shell orchestration.

## Validation
- `cargo test -p rover_server`
- `ROVER_PERF_THREADS=2 ROVER_PERF_REQUESTS_PER_THREAD=200 ROVER_PERF_MIN_RPS=1000 ROVER_PERF_MAX_P99_MS=100 cargo test -p rover_cli perf_http_echo_regression -- --ignored --nocapture`
- `bash tests/perf/run_benchmark.sh`

## Benchmark Sample (Rust Harness)
- `perf: total=16000 ok=16000 errors=0 threads=8 req_per_thread=2000 duration_ms=125 rps=127527 mean_us=61 p50_us=52 p95_us=138 p99_us=171`

## Follow-ups (tracked)
- TLS v1 server-side (rustls, TLS1.3-only, PEM)
- Real async IO/HTTP path (remove fake-yield pattern)
- Bytecode dual-engine cache pipeline
- Cert hot-reload v1.1
- HTTP/2 deferred