### PR TITLE
feat: add macos runtime and host integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ Run from repo root unless noted.
 - No released versions yet: API deprecations do not need backward-compatibility handling for now.
 - For any Rover Lua changes, ask user to confirm simplicity direction before broad edits; primary goal is extreme simplicity for humans and token efficiency for LLMs, informed by diverse ecosystems.
 - When changing the Lua API, update `docs/` in the same work so docs stay in sync with available features.
+- For all Lua API changes, update `rover-parser` and `rover-lsp` in the same work to keep autocomplete and language tooling in sync with new features.
 - If touching multiple crates, validate with targeted package tests first.
 - Prefer targeted checks before full workspace runs for faster loops.
 - Do not add new dependencies without clear need.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,6 +2617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rover-macos"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "mlua",
+ "rover_ui",
+]
+
+[[package]]
 name = "rover-openapi"
 version = "0.1.0"
 dependencies = [
@@ -2674,6 +2683,7 @@ dependencies = [
  "mlua",
  "rcgen",
  "rover-lsp",
+ "rover-macos",
  "rover-parser",
  "rover-web",
  "rover_bundler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["rover-cli" , "rover-core", "rover-server", "rover-lsp", "rover-parser", "rover-types", "rover-db", "rover-ui", "rover-runtime", "rover-bundler", "rover-tui", "rover-auth", "rover-web", "rover-web-wasm"]
+members = ["rover-cli" , "rover-core", "rover-server", "rover-lsp", "rover-parser", "rover-types", "rover-db", "rover-ui", "rover-runtime", "rover-bundler", "rover-tui", "rover-auth", "rover-web", "rover-web-wasm", "rover-macos"]
 default-members = ["rover-cli"]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ cargo build --release
 ./target/release/rover run path/to/app.lua -p web
 ```
 
+For non-web runtime development with `cargo run -p rover_cli`, use `ROVER_WEB_SKIP_AUTO_BUILD=1` to skip web asset auto-build. See the macOS runtime guide for details.
+
 ## Your First Rover App
 
 Create a simple API server:

--- a/docs/docs/guides/macos-runtime.md
+++ b/docs/docs/guides/macos-runtime.md
@@ -35,4 +35,18 @@ Run:
 rover run examples/macos_counter.lua --platform macos
 ```
 
+During local `rover_cli` development, skip the web runtime asset build when you are only testing macOS:
+
+```bash
+ROVER_WEB_SKIP_AUTO_BUILD=1 cargo run -p rover_cli -- run examples/macos_counter.lua --platform macos
+```
+
+`cargo run -p rover_cli` builds the CLI first. The CLI build script prepares embedded web assets by default, even when the command runs the macOS target. `ROVER_WEB_SKIP_AUTO_BUILD=1` writes placeholder web assets instead, so macOS iteration does not require the web/WASM toolchain.
+
+If you already have built web assets, point the build script at them instead:
+
+```bash
+ROVER_WEB_ASSETS_TAR_GZ=/absolute/path/to/rover_web_assets.tar.gz cargo run -p rover_cli -- run examples/macos_counter.lua --platform macos
+```
+
 Build/package support is intentionally deferred while the native dev loop stabilizes.

--- a/docs/docs/guides/macos-runtime.md
+++ b/docs/docs/guides/macos-runtime.md
@@ -4,6 +4,7 @@
 
 - Portable UI stays in `rover.ui`.
 - macOS-only UI lives in `rover.macos`.
+- Shared scroll containers use `rover.ui.scroll_view`.
 - Children use positional Lua table entries, not `child = ...`.
 - Layout is px-based and computed by Rover, then applied to native AppKit views.
 
@@ -19,7 +20,7 @@ function rover.render()
 
     ui.column {
       ui.text { "Hello macOS" },
-      macos.scroll_view {
+      ui.scroll_view {
         ui.column {
           ui.text { "Native AppKit" },
         },
@@ -34,6 +35,14 @@ Run:
 ```bash
 rover run examples/macos_counter.lua --platform macos
 ```
+
+Run the broader component/style showcase:
+
+```bash
+ROVER_WEB_SKIP_AUTO_BUILD=1 cargo run -p rover_cli -- run examples/macos_showcase.lua --platform macos
+```
+
+Styles use snake_case keys. macOS currently applies `bg_color`, `border_color`, `border_width`, and text `color`/`fg_color`/`text_color` to native AppKit views.
 
 During local `rover_cli` development, skip the web runtime asset build when you are only testing macOS:
 

--- a/docs/docs/guides/macos-runtime.md
+++ b/docs/docs/guides/macos-runtime.md
@@ -35,8 +35,4 @@ Run:
 rover run examples/macos_counter.lua --platform macos
 ```
 
-Build unsigned `.app` scaffold:
-
-```bash
-rover build examples/macos_counter.lua --target macos
-```
+Build/package support is intentionally deferred while the native dev loop stabilizes.

--- a/docs/docs/guides/macos-runtime.md
+++ b/docs/docs/guides/macos-runtime.md
@@ -1,0 +1,42 @@
+# macOS Runtime
+
+`rover-macos` is the native AppKit UI target.
+
+- Portable UI stays in `rover.ui`.
+- macOS-only UI lives in `rover.macos`.
+- Children use positional Lua table entries, not `child = ...`.
+- Layout is px-based and computed by Rover, then applied to native AppKit views.
+
+```lua
+local ui = rover.ui
+local macos = require("rover.macos")
+
+function rover.render()
+  return macos.window {
+    title = "Counter",
+    width = 900,
+    height = 640,
+
+    ui.column {
+      ui.text { "Hello macOS" },
+      macos.scroll_view {
+        ui.column {
+          ui.text { "Native AppKit" },
+        },
+      },
+    },
+  }
+end
+```
+
+Run:
+
+```bash
+rover run examples/macos_counter.lua --platform macos
+```
+
+Build unsigned `.app` scaffold:
+
+```bash
+rover build examples/macos_counter.lua --target macos
+```

--- a/docs/docs/guides/ui-runtime.md
+++ b/docs/docs/guides/ui-runtime.md
@@ -63,6 +63,7 @@ ru.view {
 ```
 
 - Order matters for wrapper ops (`bg_color`, `padding`, `border_*`).
+- Style table keys are snake_case, for example `bg_color`, `border_color`, `border_width`, `text_color`, `flex_grow`, `justify_content`, and `align_items`.
 - You can extend globally:
 
 ```lua

--- a/examples/macos_counter.lua
+++ b/examples/macos_counter.lua
@@ -6,11 +6,11 @@ function rover.render()
 
   return macos.window {
     title = "Rover Counter",
-    width = 900,
+    width = 300,
     height = 640,
 
     ui.column {
-      mod = ui.mod:padding(24):gap(12),
+      style = { padding = 24, gap = 12 },
       ui.text { "Count: " .. count },
       ui.button {
         label = "Increment",

--- a/examples/macos_counter.lua
+++ b/examples/macos_counter.lua
@@ -7,7 +7,7 @@ function rover.render()
   return macos.window {
     title = "Rover Counter",
     width = 300,
-    height = 640,
+    height = 300,
 
     ui.column {
       style = { padding = 24, gap = 12 },
@@ -19,9 +19,16 @@ function rover.render()
         end,
       },
       macos.scroll_view {
+        style = { height = 100, width = "full" },
         ui.column {
           ui.text { "Native AppKit scroll area" },
           ui.text { "Rover computes layout in px" },
+          ui.text { "Row 3" },
+          ui.text { "Row 4" },
+          ui.text { "Row 5" },
+          ui.text { "Row 6" },
+          ui.text { "Row 7" },
+          ui.text { "Row 8" },
         },
       },
     },

--- a/examples/macos_counter.lua
+++ b/examples/macos_counter.lua
@@ -18,17 +18,11 @@ function rover.render()
           count.val = count.val + 1
         end,
       },
-      macos.scroll_view {
+      ui.scroll_view {
         style = { height = 100, width = "full" },
         ui.column {
           ui.text { "Native AppKit scroll area" },
           ui.text { "Rover computes layout in px" },
-          ui.text { "Row 3" },
-          ui.text { "Row 4" },
-          ui.text { "Row 5" },
-          ui.text { "Row 6" },
-          ui.text { "Row 7" },
-          ui.text { "Row 8" },
         },
       },
     },

--- a/examples/macos_counter.lua
+++ b/examples/macos_counter.lua
@@ -1,0 +1,29 @@
+local ui = rover.ui
+local macos = require("rover.macos")
+
+function rover.render()
+  local count = rover.signal(0)
+
+  return macos.window {
+    title = "Rover Counter",
+    width = 900,
+    height = 640,
+
+    ui.column {
+      mod = ui.mod:padding(24):gap(12),
+      ui.text { "Count: " .. count },
+      ui.button {
+        label = "Increment",
+        on_click = function()
+          count.val = count.val + 1
+        end,
+      },
+      macos.scroll_view {
+        ui.column {
+          ui.text { "Native AppKit scroll area" },
+          ui.text { "Rover computes layout in px" },
+        },
+      },
+    },
+  }
+end

--- a/examples/macos_showcase.lua
+++ b/examples/macos_showcase.lua
@@ -38,6 +38,25 @@ function rover.render()
     return "Hello, " .. name.val .. " (pending)"
   end)
 
+  local function swatch(name, hex)
+    return ui.row {
+      style = { gap = "sm", width = "full" },
+      ui.view {
+        style = {
+          width = 120,
+          height = 24,
+          bg_color = name,
+          border_color = "border",
+          border_width = 1,
+        },
+      },
+      ui.text {
+        name .. " " .. hex,
+        style = { color = name },
+      },
+    }
+  end
+
   return macos.window {
     title = "Rover macOS Showcase",
     width = 820,
@@ -104,6 +123,25 @@ function rover.render()
       },
 
       ui.text { "Submitted input: " .. submitted },
+
+      ui.view {
+        style = {
+          padding = "md",
+          gap = "sm",
+          bg_color = "surface_alt",
+          border_color = "accent",
+          border_width = 1,
+          width = "full",
+        },
+        ui.text { "Theme colors" },
+        swatch("surface", "#0f172a"),
+        swatch("surface_alt", "#1e293b"),
+        swatch("text", "#e2e8f0"),
+        swatch("border", "#334155"),
+        swatch("accent", "#22c55e"),
+        swatch("warning", "#f59e0b"),
+        swatch("info", "#38bdf8"),
+      },
 
       ui.when(show_extra, function()
         return ui.view {

--- a/examples/macos_showcase.lua
+++ b/examples/macos_showcase.lua
@@ -1,0 +1,159 @@
+local ui = rover.ui
+local macos = require("rover.macos")
+
+ui.set_theme({
+  space = { none = 0, xs = 4, sm = 8, md = 12, lg = 16, xl = 24 },
+  color = {
+    surface = "#0f172a",
+    surface_alt = "#1e293b",
+    text = "#e2e8f0",
+    border = "#334155",
+    accent = "#22c55e",
+    warning = "#f59e0b",
+    info = "#38bdf8",
+  },
+})
+
+function rover.render()
+  local count = rover.signal(0)
+  local name = rover.signal("Rover")
+  local submitted = rover.signal("(nothing submitted yet)")
+  local agreed = rover.signal(false)
+  local show_extra = rover.signal(true)
+  local notes = rover.signal({
+    "scroll row 1",
+    "scroll row 2",
+    "scroll row 3",
+    "scroll row 4",
+    "scroll row 5",
+    "scroll row 6",
+    "scroll row 7",
+    "scroll row 8",
+  })
+
+  local greeting = rover.derive(function()
+    if agreed.val then
+      return "Hello, " .. name.val .. " (agreed)"
+    end
+    return "Hello, " .. name.val .. " (pending)"
+  end)
+
+  return macos.window {
+    title = "Rover macOS Showcase",
+    width = 820,
+    height = 620,
+
+    ui.column {
+      style = {
+        padding = "xl",
+        gap = "md",
+        width = "full",
+        height = "full",
+        bg_color = "surface",
+      },
+
+      ui.text { "Rover macOS UI showcase" },
+      ui.text { greeting },
+      ui.text { "Counter: " .. count },
+
+      ui.row {
+        style = { gap = "sm" },
+        ui.button {
+          label = "-1",
+          on_click = function()
+            count.val = count.val - 1
+          end,
+        },
+        ui.button {
+          label = "+1",
+          on_click = function()
+            count.val = count.val + 1
+          end,
+        },
+        ui.button {
+          label = "reset",
+          on_click = function()
+            count.val = 0
+          end,
+        },
+        ui.button {
+          label = "toggle extra",
+          on_click = function()
+            show_extra.val = not show_extra.val
+          end,
+        },
+      },
+
+      ui.row {
+        style = { gap = "sm" },
+        ui.input {
+          value = name,
+          on_change = function(value)
+            name.val = value
+          end,
+          on_submit = function(value)
+            submitted.val = value
+          end,
+        },
+        ui.checkbox {
+          checked = agreed,
+          on_toggle = function(value)
+            agreed.val = value
+          end,
+        },
+      },
+
+      ui.text { "Submitted input: " .. submitted },
+
+      ui.when(show_extra, function()
+        return ui.view {
+          style = {
+            padding = "md",
+            gap = "sm",
+            bg_color = "surface_alt",
+            border_color = "info",
+            border_width = 1,
+          },
+          ui.text { "Extra section (ui.when + ui.stack + ui.image)" },
+          ui.stack {
+            ui.text { "Stack base" },
+            ui.text { "Stack overlay" },
+          },
+          ui.image { src = "examples/assets/fake.png" },
+        }
+      end),
+
+      ui.text { "Scroll area (macos.scroll_view)" },
+      macos.scroll_view {
+        style = {
+          height = 170,
+          width = "full",
+          padding = "sm",
+          bg_color = "surface_alt",
+          border_color = "border",
+          border_width = 1,
+        },
+        ui.column {
+          style = { gap = "xs" },
+          ui.each(notes, function(item, index)
+            return ui.text { index .. ": " .. item }
+          end, function(item, index)
+            return item .. "-" .. index
+          end),
+        },
+      },
+
+      ui.button {
+        label = "append scroll row",
+        on_click = function()
+          local next = {}
+          for i = 1, #notes.val do
+            next[i] = notes.val[i]
+          end
+          next[#next + 1] = "scroll row " .. (#next + 1)
+          notes.val = next
+        end,
+      },
+    },
+  }
+end

--- a/rover-cli/Cargo.toml
+++ b/rover-cli/Cargo.toml
@@ -14,6 +14,7 @@ rover-parser = {path = "../rover-parser"}
 rover_db = {path = "../rover-db"}
 rover_bundler = {path = "../rover-bundler"}
 rover-web = {path = "../rover-web"}
+rover-macos = {path = "../rover-macos"}
 colored = "2.2"
 serde_json = "1.0"
 tokio = { version = "1", features = ["sync"] }

--- a/rover-cli/build_script/archive.rs
+++ b/rover-cli/build_script/archive.rs
@@ -23,6 +23,19 @@ pub fn write_runtime_archive(
     finish_archive(tar)
 }
 
+pub fn write_placeholder_archive(out_path: &Path) -> std::io::Result<()> {
+    let file = fs::File::create(out_path)?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut tar = Builder::new(encoder);
+
+    append_str(&mut tar, "index.html", embedded::runtime_index_html())?;
+    append_str(&mut tar, "loader.js", embedded::runtime_loader_js())?;
+    append_str(&mut tar, "rover_web_wasm.js", "")?;
+    append_str(&mut tar, "rover_web_wasm.wasm", "")?;
+
+    finish_archive(tar)
+}
+
 fn finish_archive(tar: Builder<GzEncoder<fs::File>>) -> std::io::Result<()> {
     let encoder = tar.into_inner()?;
     let mut file = encoder.finish()?;

--- a/rover-cli/build_script/mod.rs
+++ b/rover-cli/build_script/mod.rs
@@ -27,6 +27,13 @@ pub fn run() {
         return;
     }
 
+    if env::var(SKIP_AUTO_BUILD_ENV).is_ok() {
+        println!("cargo:warning=rover-cli build.rs: using placeholder web assets");
+        archive::write_placeholder_archive(&out_tar)
+            .expect("failed to write placeholder web assets");
+        return;
+    }
+
     println!("cargo:warning=rover-cli build.rs: auto-building rover-web-wasm");
     if let Err(err) = web_wasm::auto_build_archive(&out_tar) {
         panic!("web assets auto-build failed: {err}");

--- a/rover-cli/src/build.rs
+++ b/rover-cli/src/build.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 
 /// Supported build targets (Deno-compatible)
 pub const SUPPORTED_TARGETS: &[&str] = &[
-    "macos",
     "x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
@@ -71,20 +70,6 @@ pub fn run_build(options: BuildOptions) -> Result<()> {
     // Step 3: Serialize bundle
     let bundle_lua = serialize_bundle(&bundle);
 
-    if target == "macos" {
-        let output_name = options.output.unwrap_or_else(|| {
-            let stem = options
-                .entrypoint
-                .file_stem()
-                .unwrap_or_default()
-                .to_string_lossy();
-            PathBuf::from(format!("{}.app", stem))
-        });
-        create_macos_app(&bundle_lua, &output_name)?;
-        println!("{}", format!("✅ Built: {}", output_name.display()).green());
-        return Ok(());
-    }
-
     // Step 4: Select runtime
     let runtime_path = find_runtime(&target, features)?;
 
@@ -109,68 +94,6 @@ pub fn run_build(options: BuildOptions) -> Result<()> {
 
     println!("{}", format!("✅ Built: {}", output_name.display()).green());
     println!("   Run with: ./{} <args>", output_name.display());
-
-    Ok(())
-}
-
-fn create_macos_app(bundle: &str, output: &PathBuf) -> Result<()> {
-    let contents = output.join("Contents");
-    let macos = contents.join("MacOS");
-    let resources = contents.join("Resources");
-
-    if output.exists() {
-        fs::remove_dir_all(output).context("Failed to replace existing .app")?;
-    }
-
-    fs::create_dir_all(&macos).context("Failed to create .app MacOS directory")?;
-    fs::create_dir_all(&resources).context("Failed to create .app Resources directory")?;
-
-    let name = output
-        .file_stem()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_string();
-    let plist = format!(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>CFBundleExecutable</key><string>{name}</string>
-  <key>CFBundleIdentifier</key><string>dev.rover.{name}</string>
-  <key>CFBundleName</key><string>{name}</string>
-  <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleVersion</key><string>0.1.0</string>
-</dict>
-</plist>
-"#
-    );
-    fs::write(contents.join("Info.plist"), plist).context("Failed to write Info.plist")?;
-    fs::write(resources.join("bundle.lua"), bundle).context("Failed to write macOS bundle")?;
-
-    let host = rover_macos::build_host().context("Failed to build macOS host")?;
-    let dylib = host
-        .parent()
-        .unwrap_or(std::path::Path::new("target/debug"))
-        .join("librover_macos.dylib");
-    if !dylib.exists() {
-        return Err(anyhow::anyhow!(
-            "missing macOS runtime library: {}",
-            dylib.display()
-        ));
-    }
-
-    let launcher = macos.join(&name);
-    fs::copy(&host, &launcher).context("Failed to copy macOS host")?;
-    fs::copy(&dylib, macos.join("librover_macos.dylib"))
-        .context("Failed to copy macOS runtime library")?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&launcher)?.permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&launcher, perms)?;
-    }
 
     Ok(())
 }

--- a/rover-cli/src/build.rs
+++ b/rover-cli/src/build.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 /// Supported build targets (Deno-compatible)
 pub const SUPPORTED_TARGETS: &[&str] = &[
+    "macos",
     "x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
@@ -70,6 +71,20 @@ pub fn run_build(options: BuildOptions) -> Result<()> {
     // Step 3: Serialize bundle
     let bundle_lua = serialize_bundle(&bundle);
 
+    if target == "macos" {
+        let output_name = options.output.unwrap_or_else(|| {
+            let stem = options
+                .entrypoint
+                .file_stem()
+                .unwrap_or_default()
+                .to_string_lossy();
+            PathBuf::from(format!("{}.app", stem))
+        });
+        create_macos_app(&bundle_lua, &output_name)?;
+        println!("{}", format!("✅ Built: {}", output_name.display()).green());
+        return Ok(());
+    }
+
     // Step 4: Select runtime
     let runtime_path = find_runtime(&target, features)?;
 
@@ -94,6 +109,68 @@ pub fn run_build(options: BuildOptions) -> Result<()> {
 
     println!("{}", format!("✅ Built: {}", output_name.display()).green());
     println!("   Run with: ./{} <args>", output_name.display());
+
+    Ok(())
+}
+
+fn create_macos_app(bundle: &str, output: &PathBuf) -> Result<()> {
+    let contents = output.join("Contents");
+    let macos = contents.join("MacOS");
+    let resources = contents.join("Resources");
+
+    if output.exists() {
+        fs::remove_dir_all(output).context("Failed to replace existing .app")?;
+    }
+
+    fs::create_dir_all(&macos).context("Failed to create .app MacOS directory")?;
+    fs::create_dir_all(&resources).context("Failed to create .app Resources directory")?;
+
+    let name = output
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let plist = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key><string>{name}</string>
+  <key>CFBundleIdentifier</key><string>dev.rover.{name}</string>
+  <key>CFBundleName</key><string>{name}</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleVersion</key><string>0.1.0</string>
+</dict>
+</plist>
+"#
+    );
+    fs::write(contents.join("Info.plist"), plist).context("Failed to write Info.plist")?;
+    fs::write(resources.join("bundle.lua"), bundle).context("Failed to write macOS bundle")?;
+
+    let host = rover_macos::build_host().context("Failed to build macOS host")?;
+    let dylib = host
+        .parent()
+        .unwrap_or(std::path::Path::new("target/debug"))
+        .join("librover_macos.dylib");
+    if !dylib.exists() {
+        return Err(anyhow::anyhow!(
+            "missing macOS runtime library: {}",
+            dylib.display()
+        ));
+    }
+
+    let launcher = macos.join(&name);
+    fs::copy(&host, &launcher).context("Failed to copy macOS host")?;
+    fs::copy(&dylib, macos.join("librover_macos.dylib"))
+        .context("Failed to copy macOS runtime library")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&launcher)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&launcher, perms)?;
+    }
 
     Ok(())
 }

--- a/rover-cli/src/run.rs
+++ b/rover-cli/src/run.rs
@@ -29,10 +29,25 @@ pub fn run_file(
         Some(Platform::Stub) => run_with_stub(file, args),
         Some(Platform::Tui) => run_with_tui(file, args),
         Some(Platform::Web) => run_with_web(file, args),
+        Some(Platform::Macos) => run_with_macos(file, args),
         Some(platform) => {
             println!("Platform '{}' coming soon!", platform);
             std::process::exit(0);
         }
+    }
+}
+
+fn run_with_macos(file: PathBuf, args: Vec<String>) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        println!("Starting rover macOS UI runtime");
+        rover_macos::launch_file(&file, &args)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = args;
+        Err(anyhow::anyhow!("macOS UI runtime only runs on macOS"))
     }
 }
 

--- a/rover-db/src/lib.rs
+++ b/rover-db/src/lib.rs
@@ -103,14 +103,21 @@ pub fn create_db_module(lua: &Lua) -> LuaResult<LuaTable> {
 }
 
 enum ExecutorCommand {
-    Query { sql: String, mode: String },
+    Query {
+        sql: String,
+        mode: String,
+    },
     Insert {
         sql: String,
         table_name: String,
         data: LuaValue,
     },
-    Update { sql: String },
-    Delete { sql: String },
+    Update {
+        sql: String,
+    },
+    Delete {
+        sql: String,
+    },
     Raw {
         sql: String,
         params: Option<LuaTable>,

--- a/rover-macos/Cargo.toml
+++ b/rover-macos/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rover-macos"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["rlib", "cdylib"]
+
+[dependencies]
+anyhow = "1.0.100"
+mlua = { version = "0.11.5", features = ["anyhow", "vendored", "luajit52"] }
+rover_ui = { path = "../rover-ui" }

--- a/rover-macos/include/rover_macos.h
+++ b/rover-macos/include/rover_macos.h
@@ -1,0 +1,66 @@
+#ifndef ROVER_MACOS_H
+#define ROVER_MACOS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+typedef void *RoverNativeView;
+typedef void *RoverMacosRuntime;
+
+typedef enum RoverNativeViewKind {
+  RoverNativeViewKindWindow = 0,
+  RoverNativeViewKindView = 1,
+  RoverNativeViewKindColumn = 2,
+  RoverNativeViewKindRow = 3,
+  RoverNativeViewKindText = 4,
+  RoverNativeViewKindButton = 5,
+  RoverNativeViewKindInput = 6,
+  RoverNativeViewKindCheckbox = 7,
+  RoverNativeViewKindImage = 8,
+  RoverNativeViewKindScrollView = 9,
+} RoverNativeViewKind;
+
+typedef RoverNativeView (*RoverCreateViewFn)(uint32_t node_id, RoverNativeViewKind kind);
+typedef void (*RoverAppendChildFn)(RoverNativeView parent, RoverNativeView child);
+typedef void (*RoverRemoveViewFn)(RoverNativeView view);
+typedef void (*RoverSetFrameFn)(RoverNativeView view, float x, float y, float width, float height);
+typedef void (*RoverSetTextFn)(RoverNativeView view, const char *ptr, uintptr_t len);
+typedef void (*RoverSetBoolFn)(RoverNativeView view, bool value);
+typedef void (*RoverSetWindowFn)(RoverNativeView view, const char *title, uintptr_t len, float width, float height);
+typedef void (*RoverStopAppFn)(void);
+
+typedef struct RoverHostCallbacks {
+  RoverCreateViewFn create_view;
+  RoverAppendChildFn append_child;
+  RoverRemoveViewFn remove_view;
+  RoverSetFrameFn set_frame;
+  RoverSetTextFn set_text;
+  RoverSetBoolFn set_bool;
+  RoverSetWindowFn set_window;
+  RoverStopAppFn stop_app;
+} RoverHostCallbacks;
+
+RoverMacosRuntime rover_macos_init(RoverHostCallbacks callbacks);
+RoverMacosRuntime rover_macos_init_with_callbacks(
+  RoverCreateViewFn create_view,
+  RoverAppendChildFn append_child,
+  RoverRemoveViewFn remove_view,
+  RoverSetFrameFn set_frame,
+  RoverSetTextFn set_text,
+  RoverSetBoolFn set_bool,
+  RoverSetWindowFn set_window,
+  RoverStopAppFn stop_app
+);
+void rover_macos_free(RoverMacosRuntime runtime);
+int32_t rover_macos_load_lua(RoverMacosRuntime runtime, const char *source);
+int32_t rover_macos_tick(RoverMacosRuntime runtime);
+int32_t rover_macos_next_wake_ms(RoverMacosRuntime runtime);
+int32_t rover_macos_dispatch_click(RoverMacosRuntime runtime, uint32_t id);
+int32_t rover_macos_dispatch_input(RoverMacosRuntime runtime, uint32_t id, const char *value);
+int32_t rover_macos_dispatch_submit(RoverMacosRuntime runtime, uint32_t id, const char *value);
+int32_t rover_macos_dispatch_toggle(RoverMacosRuntime runtime, uint32_t id, bool checked);
+int32_t rover_macos_set_viewport(RoverMacosRuntime runtime, uint16_t width, uint16_t height);
+const char *rover_macos_last_error(RoverMacosRuntime runtime);
+
+#endif

--- a/rover-macos/include/rover_macos.h
+++ b/rover-macos/include/rover_macos.h
@@ -27,6 +27,7 @@ typedef void (*RoverRemoveViewFn)(RoverNativeView view);
 typedef void (*RoverSetFrameFn)(RoverNativeView view, float x, float y, float width, float height);
 typedef void (*RoverSetTextFn)(RoverNativeView view, const char *ptr, uintptr_t len);
 typedef void (*RoverSetBoolFn)(RoverNativeView view, bool value);
+typedef void (*RoverSetStyleFn)(RoverNativeView view, const char *bg_ptr, uintptr_t bg_len, const char *border_ptr, uintptr_t border_len, float border_width, const char *text_ptr, uintptr_t text_len);
 typedef void (*RoverSetWindowFn)(RoverNativeView view, const char *title, uintptr_t len, float width, float height);
 typedef void (*RoverStopAppFn)(void);
 
@@ -37,6 +38,7 @@ typedef struct RoverHostCallbacks {
   RoverSetFrameFn set_frame;
   RoverSetTextFn set_text;
   RoverSetBoolFn set_bool;
+  RoverSetStyleFn set_style;
   RoverSetWindowFn set_window;
   RoverStopAppFn stop_app;
 } RoverHostCallbacks;
@@ -49,6 +51,7 @@ RoverMacosRuntime rover_macos_init_with_callbacks(
   RoverSetFrameFn set_frame,
   RoverSetTextFn set_text,
   RoverSetBoolFn set_bool,
+  RoverSetStyleFn set_style,
   RoverSetWindowFn set_window,
   RoverStopAppFn stop_app
 );

--- a/rover-macos/src/abi.rs
+++ b/rover-macos/src/abi.rs
@@ -24,6 +24,16 @@ pub type SetFrameFn =
     extern "C" fn(view: NativeViewHandle, x: f32, y: f32, width: f32, height: f32);
 pub type SetTextFn = extern "C" fn(view: NativeViewHandle, ptr: *const c_char, len: usize);
 pub type SetBoolFn = extern "C" fn(view: NativeViewHandle, value: bool);
+pub type SetStyleFn = extern "C" fn(
+    view: NativeViewHandle,
+    bg_ptr: *const c_char,
+    bg_len: usize,
+    border_ptr: *const c_char,
+    border_len: usize,
+    border_width: f32,
+    text_ptr: *const c_char,
+    text_len: usize,
+);
 pub type SetWindowFn = extern "C" fn(
     view: NativeViewHandle,
     title: *const c_char,
@@ -42,6 +52,7 @@ pub struct HostCallbacks {
     pub set_frame: Option<SetFrameFn>,
     pub set_text: Option<SetTextFn>,
     pub set_bool: Option<SetBoolFn>,
+    pub set_style: Option<SetStyleFn>,
     pub set_window: Option<SetWindowFn>,
     pub stop_app: Option<StopAppFn>,
 }

--- a/rover-macos/src/abi.rs
+++ b/rover-macos/src/abi.rs
@@ -1,0 +1,47 @@
+use std::ffi::{c_char, c_void};
+
+pub type NativeViewHandle = *mut c_void;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeViewKind {
+    Window = 0,
+    View = 1,
+    Column = 2,
+    Row = 3,
+    Text = 4,
+    Button = 5,
+    Input = 6,
+    Checkbox = 7,
+    Image = 8,
+    ScrollView = 9,
+}
+
+pub type CreateViewFn = extern "C" fn(node_id: u32, kind: NativeViewKind) -> NativeViewHandle;
+pub type AppendChildFn = extern "C" fn(parent: NativeViewHandle, child: NativeViewHandle);
+pub type RemoveViewFn = extern "C" fn(view: NativeViewHandle);
+pub type SetFrameFn =
+    extern "C" fn(view: NativeViewHandle, x: f32, y: f32, width: f32, height: f32);
+pub type SetTextFn = extern "C" fn(view: NativeViewHandle, ptr: *const c_char, len: usize);
+pub type SetBoolFn = extern "C" fn(view: NativeViewHandle, value: bool);
+pub type SetWindowFn = extern "C" fn(
+    view: NativeViewHandle,
+    title: *const c_char,
+    len: usize,
+    width: f32,
+    height: f32,
+);
+pub type StopAppFn = extern "C" fn();
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct HostCallbacks {
+    pub create_view: Option<CreateViewFn>,
+    pub append_child: Option<AppendChildFn>,
+    pub remove_view: Option<RemoveViewFn>,
+    pub set_frame: Option<SetFrameFn>,
+    pub set_text: Option<SetTextFn>,
+    pub set_bool: Option<SetBoolFn>,
+    pub set_window: Option<SetWindowFn>,
+    pub stop_app: Option<StopAppFn>,
+}

--- a/rover-macos/src/abi_export.rs
+++ b/rover-macos/src/abi_export.rs
@@ -1,6 +1,6 @@
 use crate::abi::{
-    AppendChildFn, CreateViewFn, HostCallbacks, RemoveViewFn, SetBoolFn, SetFrameFn, SetTextFn,
-    SetWindowFn, StopAppFn,
+    AppendChildFn, CreateViewFn, HostCallbacks, RemoveViewFn, SetBoolFn, SetFrameFn, SetStyleFn,
+    SetTextFn, SetWindowFn, StopAppFn,
 };
 use crate::runtime::MacosRuntime;
 use std::ffi::{CStr, CString, c_char};
@@ -47,6 +47,7 @@ pub unsafe extern "C" fn rover_macos_init_with_callbacks(
     set_frame: Option<SetFrameFn>,
     set_text: Option<SetTextFn>,
     set_bool: Option<SetBoolFn>,
+    set_style: Option<SetStyleFn>,
     set_window: Option<SetWindowFn>,
     stop_app: Option<StopAppFn>,
 ) -> *mut FfiRuntime {
@@ -58,6 +59,7 @@ pub unsafe extern "C" fn rover_macos_init_with_callbacks(
             set_frame,
             set_text,
             set_bool,
+            set_style,
             set_window,
             stop_app,
         })

--- a/rover-macos/src/abi_export.rs
+++ b/rover-macos/src/abi_export.rs
@@ -1,0 +1,196 @@
+use crate::abi::{
+    AppendChildFn, CreateViewFn, HostCallbacks, RemoveViewFn, SetBoolFn, SetFrameFn, SetTextFn,
+    SetWindowFn, StopAppFn,
+};
+use crate::runtime::MacosRuntime;
+use std::ffi::{CStr, CString, c_char};
+
+pub struct FfiRuntime {
+    runtime: MacosRuntime,
+    last_error: CString,
+}
+
+impl FfiRuntime {
+    fn new(callbacks: HostCallbacks) -> Result<Self, String> {
+        Ok(Self {
+            runtime: MacosRuntime::new(callbacks).map_err(|e| e.to_string())?,
+            last_error: CString::new("").expect("empty string has no nul"),
+        })
+    }
+
+    fn clear_error(&mut self) {
+        self.last_error = CString::new("").expect("empty string has no nul");
+    }
+
+    fn set_error(&mut self, error: impl AsRef<str>) {
+        self.last_error = CString::new(error.as_ref().replace('\0', ""))
+            .expect("nul bytes removed before CString");
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_init(callbacks: HostCallbacks) -> *mut FfiRuntime {
+    match FfiRuntime::new(callbacks) {
+        Ok(runtime) => Box::into_raw(Box::new(runtime)),
+        Err(err) => {
+            eprintln!("{err}");
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_init_with_callbacks(
+    create_view: Option<CreateViewFn>,
+    append_child: Option<AppendChildFn>,
+    remove_view: Option<RemoveViewFn>,
+    set_frame: Option<SetFrameFn>,
+    set_text: Option<SetTextFn>,
+    set_bool: Option<SetBoolFn>,
+    set_window: Option<SetWindowFn>,
+    stop_app: Option<StopAppFn>,
+) -> *mut FfiRuntime {
+    unsafe {
+        rover_macos_init(HostCallbacks {
+            create_view,
+            append_child,
+            remove_view,
+            set_frame,
+            set_text,
+            set_bool,
+            set_window,
+            stop_app,
+        })
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_free(runtime: *mut FfiRuntime) {
+    if !runtime.is_null() {
+        let _ = unsafe { Box::from_raw(runtime) };
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_load_lua(
+    runtime: *mut FfiRuntime,
+    source: *const c_char,
+) -> i32 {
+    if runtime.is_null() || source.is_null() {
+        return 1;
+    }
+
+    let runtime = unsafe { &mut *runtime };
+    runtime.clear_error();
+    let source = unsafe { CStr::from_ptr(source) }.to_string_lossy();
+    match runtime.runtime.load_lua(source.as_ref()) {
+        Ok(_) => 0,
+        Err(err) => {
+            runtime.set_error(err.to_string());
+            2
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_tick(runtime: *mut FfiRuntime) -> i32 {
+    if runtime.is_null() {
+        return 1;
+    }
+
+    let runtime = unsafe { &mut *runtime };
+    runtime.clear_error();
+    match runtime.runtime.tick() {
+        Ok(_) => 0,
+        Err(err) => {
+            runtime.set_error(err.to_string());
+            2
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_next_wake_ms(runtime: *mut FfiRuntime) -> i32 {
+    if runtime.is_null() {
+        return -1;
+    }
+
+    unsafe { &*runtime }.runtime.next_wake_ms()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_dispatch_click(runtime: *mut FfiRuntime, id: u32) -> i32 {
+    if runtime.is_null() {
+        return 1;
+    }
+    unsafe { &mut *runtime }.runtime.dispatch_click(id);
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_dispatch_input(
+    runtime: *mut FfiRuntime,
+    id: u32,
+    value: *const c_char,
+) -> i32 {
+    if runtime.is_null() || value.is_null() {
+        return 1;
+    }
+    let value = unsafe { CStr::from_ptr(value) }
+        .to_string_lossy()
+        .to_string();
+    unsafe { &mut *runtime }.runtime.dispatch_input(id, value);
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_dispatch_submit(
+    runtime: *mut FfiRuntime,
+    id: u32,
+    value: *const c_char,
+) -> i32 {
+    if runtime.is_null() || value.is_null() {
+        return 1;
+    }
+    let value = unsafe { CStr::from_ptr(value) }
+        .to_string_lossy()
+        .to_string();
+    unsafe { &mut *runtime }.runtime.dispatch_submit(id, value);
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_dispatch_toggle(
+    runtime: *mut FfiRuntime,
+    id: u32,
+    checked: bool,
+) -> i32 {
+    if runtime.is_null() {
+        return 1;
+    }
+    unsafe { &mut *runtime }
+        .runtime
+        .dispatch_toggle(id, checked);
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_set_viewport(
+    runtime: *mut FfiRuntime,
+    width: u16,
+    height: u16,
+) -> i32 {
+    if runtime.is_null() {
+        return 1;
+    }
+    unsafe { &mut *runtime }.runtime.set_viewport(width, height);
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rover_macos_last_error(runtime: *mut FfiRuntime) -> *const c_char {
+    if runtime.is_null() {
+        return std::ptr::null();
+    }
+    unsafe { &*runtime }.last_error.as_ptr()
+}

--- a/rover-macos/src/layout.rs
+++ b/rover-macos/src/layout.rs
@@ -111,8 +111,8 @@ fn compute_node(
         | UiNode::View { children }
         | UiNode::Stack { children }
         | UiNode::List { children, .. }
-        | UiNode::MacosWindow { children, .. }
-        | UiNode::MacosScrollView { children } => {
+        | UiNode::ScrollView { children }
+        | UiNode::MacosWindow { children, .. } => {
             layout_column(registry, node_id, children, available, padding, gap, layout)
         }
         UiNode::ScrollBox { child, .. }

--- a/rover-macos/src/layout.rs
+++ b/rover-macos/src/layout.rs
@@ -9,6 +9,17 @@ pub struct Rect {
     pub height: f32,
 }
 
+impl Rect {
+    pub fn relative_to(self, parent: Rect) -> Self {
+        Self {
+            x: self.x - parent.x,
+            y: self.y - parent.y,
+            width: self.width,
+            height: self.height,
+        }
+    }
+}
+
 pub struct LayoutMap {
     entries: Vec<Option<Rect>>,
 }
@@ -288,5 +299,31 @@ mod tests {
 
         assert_eq!(layout.get(first).unwrap().y, 0.0);
         assert_eq!(layout.get(second).unwrap().y, 20.0);
+    }
+
+    #[test]
+    fn converts_absolute_rect_to_parent_relative_frame() {
+        let parent = Rect {
+            x: 24.0,
+            y: 62.0,
+            width: 252.0,
+            height: 100.0,
+        };
+        let child = Rect {
+            x: 24.0,
+            y: 62.0,
+            width: 252.0,
+            height: 80.0,
+        };
+
+        assert_eq!(
+            child.relative_to(parent),
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 252.0,
+                height: 80.0,
+            }
+        );
     }
 }

--- a/rover-macos/src/layout.rs
+++ b/rover-macos/src/layout.rs
@@ -1,0 +1,292 @@
+use rover_ui::ui::{NodeId, NodeStyle, StyleOp, StyleSize, UiNode, UiRegistry};
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct Rect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+pub struct LayoutMap {
+    entries: Vec<Option<Rect>>,
+}
+
+impl LayoutMap {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn set(&mut self, id: NodeId, rect: Rect) {
+        let idx = id.index();
+        if idx >= self.entries.len() {
+            self.entries.resize(idx + 1, None);
+        }
+        self.entries[idx] = Some(rect);
+    }
+
+    pub fn get(&self, id: NodeId) -> Option<Rect> {
+        self.entries.get(id.index()).and_then(|entry| *entry)
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+}
+
+impl Default for LayoutMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn compute_layout(
+    registry: &UiRegistry,
+    root: NodeId,
+    viewport_width: f32,
+    viewport_height: f32,
+) -> LayoutMap {
+    let mut layout = LayoutMap::new();
+    compute_node(
+        registry,
+        root,
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: viewport_width,
+            height: viewport_height,
+        },
+        &mut layout,
+    );
+    layout
+}
+
+fn compute_node(
+    registry: &UiRegistry,
+    node_id: NodeId,
+    available: Rect,
+    layout: &mut LayoutMap,
+) -> Rect {
+    let Some(node) = registry.get_node(node_id) else {
+        return Rect::default();
+    };
+    let style = registry
+        .get_node_style(node_id)
+        .cloned()
+        .unwrap_or_default();
+    let padding = padding(&style);
+    let gap = style.gap.unwrap_or(0) as f32;
+
+    let mut rect = match node {
+        UiNode::Text { content } => leaf_rect(&style, available, text_width(content.value()), 20.0),
+        UiNode::Button { label, .. } => {
+            leaf_rect(&style, available, text_width(label) + 28.0, 30.0)
+        }
+        UiNode::Input { value, .. } => leaf_rect(
+            &style,
+            available,
+            text_width(value.value()).max(160.0),
+            28.0,
+        ),
+        UiNode::Checkbox { .. } => leaf_rect(&style, available, 22.0, 22.0),
+        UiNode::Image { .. } => leaf_rect(&style, available, 0.0, 0.0),
+        UiNode::Row { children } => {
+            layout_row(registry, node_id, children, available, padding, gap, layout)
+        }
+        UiNode::Column { children }
+        | UiNode::View { children }
+        | UiNode::Stack { children }
+        | UiNode::List { children, .. }
+        | UiNode::MacosWindow { children, .. }
+        | UiNode::MacosScrollView { children } => {
+            layout_column(registry, node_id, children, available, padding, gap, layout)
+        }
+        UiNode::ScrollBox { child, .. }
+        | UiNode::FullScreen { child, .. }
+        | UiNode::Conditional { child, .. }
+        | UiNode::KeyArea { child, .. } => {
+            let children: Vec<NodeId> = child.iter().copied().collect();
+            layout_column(
+                registry, node_id, &children, available, padding, gap, layout,
+            )
+        }
+    };
+
+    apply_size(&style, available, &mut rect);
+    layout.set(node_id, rect);
+    rect
+}
+
+fn layout_column(
+    registry: &UiRegistry,
+    node_id: NodeId,
+    children: &[NodeId],
+    available: Rect,
+    padding: f32,
+    gap: f32,
+    layout: &mut LayoutMap,
+) -> Rect {
+    let mut y = available.y + padding;
+    let inner_width = (available.width - padding * 2.0).max(0.0);
+    let mut used_height: f32 = padding * 2.0;
+    let mut max_width: f32 = 0.0;
+
+    for (index, child) in children.iter().enumerate() {
+        if index > 0 {
+            y += gap;
+            used_height += gap;
+        }
+        let child_rect = compute_node(
+            registry,
+            *child,
+            Rect {
+                x: available.x + padding,
+                y,
+                width: inner_width,
+                height: available.height,
+            },
+            layout,
+        );
+        y += child_rect.height;
+        used_height += child_rect.height;
+        max_width = max_width.max(child_rect.width);
+    }
+
+    let style = registry
+        .get_node_style(node_id)
+        .cloned()
+        .unwrap_or_default();
+    let mut rect = Rect {
+        x: available.x,
+        y: available.y,
+        width: (max_width + padding * 2.0).max(available.width),
+        height: used_height.max(0.0),
+    };
+    apply_size(&style, available, &mut rect);
+    rect
+}
+
+fn layout_row(
+    registry: &UiRegistry,
+    node_id: NodeId,
+    children: &[NodeId],
+    available: Rect,
+    padding: f32,
+    gap: f32,
+    layout: &mut LayoutMap,
+) -> Rect {
+    let mut x = available.x + padding;
+    let inner_height = (available.height - padding * 2.0).max(0.0);
+    let mut used_width: f32 = padding * 2.0;
+    let mut max_height: f32 = 0.0;
+
+    for (index, child) in children.iter().enumerate() {
+        if index > 0 {
+            x += gap;
+            used_width += gap;
+        }
+        let child_rect = compute_node(
+            registry,
+            *child,
+            Rect {
+                x,
+                y: available.y + padding,
+                width: available.width,
+                height: inner_height,
+            },
+            layout,
+        );
+        x += child_rect.width;
+        used_width += child_rect.width;
+        max_height = max_height.max(child_rect.height);
+    }
+
+    let style = registry
+        .get_node_style(node_id)
+        .cloned()
+        .unwrap_or_default();
+    let mut rect = Rect {
+        x: available.x,
+        y: available.y,
+        width: used_width,
+        height: (max_height + padding * 2.0).max(0.0),
+    };
+    apply_size(&style, available, &mut rect);
+    rect
+}
+
+fn leaf_rect(
+    style: &NodeStyle,
+    available: Rect,
+    intrinsic_width: f32,
+    intrinsic_height: f32,
+) -> Rect {
+    let padding = padding(style);
+    let mut rect = Rect {
+        x: available.x,
+        y: available.y,
+        width: intrinsic_width + padding * 2.0,
+        height: intrinsic_height + padding * 2.0,
+    };
+    apply_size(style, available, &mut rect);
+    rect
+}
+
+fn apply_size(style: &NodeStyle, available: Rect, rect: &mut Rect) {
+    if let Some(width) = style.width {
+        rect.width = match width {
+            StyleSize::Full => available.width,
+            StyleSize::Px(value) => value as f32,
+        };
+    }
+    if let Some(height) = style.height {
+        rect.height = match height {
+            StyleSize::Full => available.height,
+            StyleSize::Px(value) => value as f32,
+        };
+    }
+}
+
+fn padding(style: &NodeStyle) -> f32 {
+    style
+        .ops
+        .iter()
+        .rev()
+        .find_map(|op| match op {
+            StyleOp::Padding(value) => Some(*value as f32),
+            _ => None,
+        })
+        .unwrap_or(0.0)
+}
+
+fn text_width(text: &str) -> f32 {
+    text.chars().count() as f32 * 7.5
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rover_ui::ui::{TextContent, UiRegistry};
+
+    #[test]
+    fn lays_out_column_children_in_px() {
+        let mut registry = UiRegistry::new();
+        let first = registry.create_node(UiNode::Text {
+            content: TextContent::Static("a".to_string()),
+        });
+        let second = registry.create_node(UiNode::Text {
+            content: TextContent::Static("b".to_string()),
+        });
+        let root = registry.create_node(UiNode::Column {
+            children: vec![first, second],
+        });
+
+        let layout = compute_layout(&registry, root, 900.0, 640.0);
+
+        assert_eq!(layout.get(first).unwrap().y, 0.0);
+        assert_eq!(layout.get(second).unwrap().y, 20.0);
+    }
+}

--- a/rover-macos/src/lib.rs
+++ b/rover-macos/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod abi;
+pub mod abi_export;
+pub mod layout;
+pub mod renderer;
+pub mod runtime;
+
+pub use abi::{HostCallbacks, NativeViewKind};
+pub use renderer::MacosRenderer;
+pub use runtime::{MacosRuntime, build_host, launch_file, run_file};

--- a/rover-macos/src/renderer.rs
+++ b/rover-macos/src/renderer.rs
@@ -1,0 +1,295 @@
+use crate::abi::{HostCallbacks, NativeViewHandle, NativeViewKind};
+use crate::layout::{LayoutMap, compute_layout};
+use rover_ui::platform::UiTarget;
+use rover_ui::ui::{NodeId, Renderer, UiNode, UiRegistry};
+use std::collections::HashSet;
+use std::ffi::c_void;
+
+const DEFAULT_WIDTH: f32 = 900.0;
+const DEFAULT_HEIGHT: f32 = 640.0;
+const SYNTHETIC_WINDOW_ID: u32 = u32::MAX;
+
+pub struct MacosRenderer {
+    callbacks: HostCallbacks,
+    handles: Vec<Option<NativeViewHandle>>,
+    layout: LayoutMap,
+    viewport_width: f32,
+    viewport_height: f32,
+    default_window: Option<NativeViewHandle>,
+    attached_edges: HashSet<(u32, u32)>,
+}
+
+impl MacosRenderer {
+    pub fn new(callbacks: HostCallbacks) -> Self {
+        Self {
+            callbacks,
+            handles: Vec::new(),
+            layout: LayoutMap::new(),
+            viewport_width: DEFAULT_WIDTH,
+            viewport_height: DEFAULT_HEIGHT,
+            default_window: None,
+            attached_edges: HashSet::new(),
+        }
+    }
+
+    pub fn set_viewport_size(&mut self, width: f32, height: f32) {
+        self.viewport_width = width.max(1.0);
+        self.viewport_height = height.max(1.0);
+    }
+
+    fn set_handle(&mut self, node_id: NodeId, handle: NativeViewHandle) {
+        let idx = node_id.index();
+        if idx >= self.handles.len() {
+            self.handles.resize(idx + 1, None);
+        }
+        self.handles[idx] = Some(handle);
+    }
+
+    fn handle(&self, node_id: NodeId) -> Option<NativeViewHandle> {
+        self.handles.get(node_id.index()).and_then(|entry| *entry)
+    }
+
+    fn create_subtree(
+        &mut self,
+        registry: &UiRegistry,
+        node_id: NodeId,
+    ) -> Option<NativeViewHandle> {
+        let node = registry.get_node(node_id)?;
+        if let Some(handle) = self.handle(node_id) {
+            return Some(handle);
+        }
+
+        let handle = self.create_view(node_id, kind_for_node(node));
+        self.set_handle(node_id, handle);
+        self.apply_node_props(node_id, node, handle);
+
+        for child in children_for_node(node) {
+            if let Some(child_handle) = self.create_subtree(registry, child) {
+                if let Some(append_child) = self.callbacks.append_child {
+                    append_child(handle, child_handle);
+                }
+            }
+        }
+
+        Some(handle)
+    }
+
+    fn mount_root(&mut self, registry: &UiRegistry, root: NodeId) {
+        if matches!(registry.get_node(root), Some(UiNode::MacosWindow { .. })) {
+            self.create_subtree(registry, root);
+            return;
+        }
+
+        let window = self.default_window.unwrap_or_else(|| {
+            let handle = self.create_view_raw(SYNTHETIC_WINDOW_ID, NativeViewKind::Window);
+            self.set_window(handle, "Rover", DEFAULT_WIDTH, DEFAULT_HEIGHT);
+            self.default_window = Some(handle);
+            handle
+        });
+
+        if let Some(root_handle) = self.create_subtree(registry, root) {
+            self.append_child_once(
+                SYNTHETIC_WINDOW_ID,
+                root.index() as u32,
+                window,
+                root_handle,
+            );
+        }
+    }
+
+    fn sync_subtree(&mut self, registry: &UiRegistry, node_id: NodeId) {
+        let Some(node) = registry.get_node(node_id) else {
+            return;
+        };
+        let Some(parent_handle) = self.handle(node_id) else {
+            return;
+        };
+
+        for child in children_for_node(node) {
+            if self.handle(child).is_none() {
+                self.create_subtree(registry, child);
+            }
+            if let Some(child_handle) = self.handle(child) {
+                self.append_child_once(
+                    node_id.index() as u32,
+                    child.index() as u32,
+                    parent_handle,
+                    child_handle,
+                );
+            }
+            self.sync_subtree(registry, child);
+        }
+    }
+
+    fn append_child_once(
+        &mut self,
+        parent_id: u32,
+        child_id: u32,
+        parent: NativeViewHandle,
+        child: NativeViewHandle,
+    ) {
+        if !self.attached_edges.insert((parent_id, child_id)) {
+            return;
+        }
+        if let Some(append_child) = self.callbacks.append_child {
+            append_child(parent, child);
+        }
+    }
+
+    fn create_view(&self, node_id: NodeId, kind: NativeViewKind) -> NativeViewHandle {
+        self.create_view_raw(node_id.index() as u32, kind)
+    }
+
+    fn create_view_raw(&self, node_id: u32, kind: NativeViewKind) -> NativeViewHandle {
+        if let Some(create_view) = self.callbacks.create_view {
+            create_view(node_id, kind)
+        } else {
+            std::ptr::null_mut::<c_void>()
+        }
+    }
+
+    fn apply_node_props(&self, node_id: NodeId, node: &UiNode, handle: NativeViewHandle) {
+        match node {
+            UiNode::Text { content } => self.set_text(handle, content.value()),
+            UiNode::Button { label, .. } => self.set_text(handle, label),
+            UiNode::Input { value, .. } => self.set_text(handle, value.value()),
+            UiNode::Checkbox { checked, .. } => {
+                if let Some(set_bool) = self.callbacks.set_bool {
+                    set_bool(handle, *checked);
+                }
+            }
+            UiNode::Image { src } => self.set_text(handle, src),
+            UiNode::MacosWindow {
+                title,
+                width,
+                height,
+                ..
+            } => {
+                if let Some(set_window) = self.callbacks.set_window {
+                    set_window(
+                        handle,
+                        title.as_ptr().cast(),
+                        title.len(),
+                        *width as f32,
+                        *height as f32,
+                    );
+                }
+            }
+            _ => {
+                let _ = node_id;
+            }
+        }
+    }
+
+    fn set_text(&self, handle: NativeViewHandle, text: &str) {
+        if let Some(set_text) = self.callbacks.set_text {
+            set_text(handle, text.as_ptr().cast(), text.len());
+        }
+    }
+
+    fn set_window(&self, handle: NativeViewHandle, title: &str, width: f32, height: f32) {
+        if let Some(set_window) = self.callbacks.set_window {
+            set_window(handle, title.as_ptr().cast(), title.len(), width, height);
+        }
+    }
+
+    fn apply_layout(&self, registry: &UiRegistry, node_id: NodeId) {
+        if let (Some(handle), Some(rect), Some(set_frame)) = (
+            self.handle(node_id),
+            self.layout.get(node_id),
+            self.callbacks.set_frame,
+        ) {
+            set_frame(handle, rect.x, rect.y, rect.width, rect.height);
+        }
+
+        if let Some(node) = registry.get_node(node_id) {
+            for child in children_for_node(node) {
+                self.apply_layout(registry, child);
+            }
+        }
+    }
+}
+
+impl Renderer for MacosRenderer {
+    fn mount(&mut self, registry: &UiRegistry) {
+        if let Some(root) = registry.root() {
+            self.mount_root(registry, root);
+            self.sync_subtree(registry, root);
+            self.layout = compute_layout(registry, root, self.viewport_width, self.viewport_height);
+            self.apply_layout(registry, root);
+        }
+    }
+
+    fn update(&mut self, registry: &UiRegistry, dirty_nodes: &[NodeId]) {
+        if let Some(root) = registry.root() {
+            self.mount_root(registry, root);
+            self.sync_subtree(registry, root);
+            self.layout = compute_layout(registry, root, self.viewport_width, self.viewport_height);
+            self.apply_layout(registry, root);
+        }
+
+        for node_id in dirty_nodes {
+            let Some(node) = registry.get_node(*node_id) else {
+                continue;
+            };
+            if self.handle(*node_id).is_none() {
+                self.create_subtree(registry, *node_id);
+            }
+            if let Some(handle) = self.handle(*node_id) {
+                self.apply_node_props(*node_id, node, handle);
+            }
+        }
+    }
+
+    fn node_added(&mut self, registry: &UiRegistry, node_id: NodeId) {
+        self.create_subtree(registry, node_id);
+    }
+
+    fn node_removed(&mut self, node_id: NodeId) {
+        if let Some(handle) = self.handle(node_id) {
+            if let Some(remove_view) = self.callbacks.remove_view {
+                remove_view(handle);
+            }
+        }
+        if let Some(entry) = self.handles.get_mut(node_id.index()) {
+            *entry = None;
+        }
+    }
+
+    fn target(&self) -> UiTarget {
+        UiTarget::Macos
+    }
+}
+
+fn kind_for_node(node: &UiNode) -> NativeViewKind {
+    match node {
+        UiNode::Text { .. } => NativeViewKind::Text,
+        UiNode::Button { .. } => NativeViewKind::Button,
+        UiNode::Input { .. } => NativeViewKind::Input,
+        UiNode::Checkbox { .. } => NativeViewKind::Checkbox,
+        UiNode::Image { .. } => NativeViewKind::Image,
+        UiNode::Row { .. } => NativeViewKind::Row,
+        UiNode::MacosWindow { .. } => NativeViewKind::Window,
+        UiNode::MacosScrollView { .. } | UiNode::ScrollBox { .. } => NativeViewKind::ScrollView,
+        _ => NativeViewKind::Column,
+    }
+}
+
+fn children_for_node(node: &UiNode) -> Vec<NodeId> {
+    match node {
+        UiNode::Column { children }
+        | UiNode::Row { children }
+        | UiNode::View { children }
+        | UiNode::Stack { children }
+        | UiNode::List { children, .. }
+        | UiNode::MacosWindow { children, .. }
+        | UiNode::MacosScrollView { children } => children.clone(),
+        UiNode::ScrollBox { child, .. }
+        | UiNode::FullScreen { child, .. }
+        | UiNode::Conditional { child, .. }
+        | UiNode::KeyArea { child, .. } => child.iter().copied().collect(),
+        _ => Vec::new(),
+    }
+}
+
+unsafe impl Send for MacosRenderer {}

--- a/rover-macos/src/renderer.rs
+++ b/rover-macos/src/renderer.rs
@@ -1,7 +1,7 @@
 use crate::abi::{HostCallbacks, NativeViewHandle, NativeViewKind};
 use crate::layout::{LayoutMap, Rect, compute_layout};
 use rover_ui::platform::UiTarget;
-use rover_ui::ui::{NodeId, Renderer, UiNode, UiRegistry};
+use rover_ui::ui::{NodeId, Renderer, StyleOp, UiNode, UiRegistry};
 use std::collections::HashSet;
 use std::ffi::c_void;
 
@@ -210,6 +210,10 @@ impl MacosRenderer {
             return;
         };
 
+        if let Some(handle) = self.handle(node_id) {
+            self.apply_style(registry, node_id, handle);
+        }
+
         if !matches!(node, UiNode::MacosWindow { .. }) {
             if let (Some(handle), Some(set_frame)) =
                 (self.handle(node_id), self.callbacks.set_frame)
@@ -222,6 +226,40 @@ impl MacosRenderer {
         for child in children_for_node(node) {
             self.apply_layout_relative_to(registry, child, Some(rect));
         }
+    }
+
+    fn apply_style(&self, registry: &UiRegistry, node_id: NodeId, handle: NativeViewHandle) {
+        let Some(set_style) = self.callbacks.set_style else {
+            return;
+        };
+        let Some(style) = registry.get_node_style(node_id) else {
+            return;
+        };
+
+        let mut bg = "";
+        let mut border = "";
+        let mut border_width = 0.0;
+
+        for op in &style.ops {
+            match op {
+                StyleOp::BgColor(value) => bg = value,
+                StyleOp::BorderColor(value) => border = value,
+                StyleOp::BorderWidth(value) => border_width = *value as f32,
+                StyleOp::Padding(_) => {}
+            }
+        }
+
+        let text = style.color.as_deref().unwrap_or("");
+        set_style(
+            handle,
+            bg.as_ptr().cast(),
+            bg.len(),
+            border.as_ptr().cast(),
+            border.len(),
+            border_width,
+            text.as_ptr().cast(),
+            text.len(),
+        );
     }
 }
 

--- a/rover-macos/src/renderer.rs
+++ b/rover-macos/src/renderer.rs
@@ -1,5 +1,5 @@
 use crate::abi::{HostCallbacks, NativeViewHandle, NativeViewKind};
-use crate::layout::{LayoutMap, compute_layout};
+use crate::layout::{LayoutMap, Rect, compute_layout};
 use rover_ui::platform::UiTarget;
 use rover_ui::ui::{NodeId, Renderer, UiNode, UiRegistry};
 use std::collections::HashSet;
@@ -194,18 +194,33 @@ impl MacosRenderer {
     }
 
     fn apply_layout(&self, registry: &UiRegistry, node_id: NodeId) {
-        if let (Some(handle), Some(rect), Some(set_frame)) = (
-            self.handle(node_id),
-            self.layout.get(node_id),
-            self.callbacks.set_frame,
-        ) {
-            set_frame(handle, rect.x, rect.y, rect.width, rect.height);
+        self.apply_layout_relative_to(registry, node_id, None);
+    }
+
+    fn apply_layout_relative_to(
+        &self,
+        registry: &UiRegistry,
+        node_id: NodeId,
+        parent_rect: Option<Rect>,
+    ) {
+        let Some(node) = registry.get_node(node_id) else {
+            return;
+        };
+        let Some(rect) = self.layout.get(node_id) else {
+            return;
+        };
+
+        if !matches!(node, UiNode::MacosWindow { .. }) {
+            if let (Some(handle), Some(set_frame)) =
+                (self.handle(node_id), self.callbacks.set_frame)
+            {
+                let frame = rect.relative_to(parent_rect.unwrap_or_default());
+                set_frame(handle, frame.x, frame.y, frame.width, frame.height);
+            }
         }
 
-        if let Some(node) = registry.get_node(node_id) {
-            for child in children_for_node(node) {
-                self.apply_layout(registry, child);
-            }
+        for child in children_for_node(node) {
+            self.apply_layout_relative_to(registry, child, Some(rect));
         }
     }
 }

--- a/rover-macos/src/renderer.rs
+++ b/rover-macos/src/renderer.rs
@@ -323,7 +323,7 @@ fn kind_for_node(node: &UiNode) -> NativeViewKind {
         UiNode::Image { .. } => NativeViewKind::Image,
         UiNode::Row { .. } => NativeViewKind::Row,
         UiNode::MacosWindow { .. } => NativeViewKind::Window,
-        UiNode::MacosScrollView { .. } | UiNode::ScrollBox { .. } => NativeViewKind::ScrollView,
+        UiNode::ScrollView { .. } | UiNode::ScrollBox { .. } => NativeViewKind::ScrollView,
         _ => NativeViewKind::Column,
     }
 }
@@ -335,8 +335,8 @@ fn children_for_node(node: &UiNode) -> Vec<NodeId> {
         | UiNode::View { children }
         | UiNode::Stack { children }
         | UiNode::List { children, .. }
-        | UiNode::MacosWindow { children, .. }
-        | UiNode::MacosScrollView { children } => children.clone(),
+        | UiNode::ScrollView { children }
+        | UiNode::MacosWindow { children, .. } => children.clone(),
         UiNode::ScrollBox { child, .. }
         | UiNode::FullScreen { child, .. }
         | UiNode::Conditional { child, .. }

--- a/rover-macos/src/runtime.rs
+++ b/rover-macos/src/runtime.rs
@@ -77,6 +77,10 @@ impl MacosRuntime {
         self.app
             .renderer()
             .set_viewport_size(width as f32, height as f32);
+        let root = self.app.registry().borrow().root();
+        if let Some(root) = root {
+            self.app.registry().borrow_mut().mark_dirty(root);
+        }
     }
 }
 

--- a/rover-macos/src/runtime.rs
+++ b/rover-macos/src/runtime.rs
@@ -1,0 +1,129 @@
+use crate::abi::HostCallbacks;
+use crate::renderer::MacosRenderer;
+use anyhow::Result;
+use rover_ui::app::App;
+use rover_ui::events::UiEvent;
+use rover_ui::ui::NodeId;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Instant;
+
+pub struct MacosRuntime {
+    app: App<MacosRenderer>,
+}
+
+impl MacosRuntime {
+    pub fn new(callbacks: HostCallbacks) -> mlua::Result<Self> {
+        let renderer = MacosRenderer::new(callbacks);
+        let app = App::new(renderer)?;
+        Ok(Self { app })
+    }
+
+    pub fn load_lua(&mut self, source: &str) -> mlua::Result<()> {
+        self.app.run_script(source)?;
+        self.app.mount()
+    }
+
+    pub fn tick(&mut self) -> mlua::Result<bool> {
+        self.app.tick()
+    }
+
+    pub fn next_wake_ms(&self) -> i32 {
+        self.app
+            .next_wake_time()
+            .map(|wake| {
+                let now = Instant::now();
+                if wake <= now {
+                    0
+                } else {
+                    wake.saturating_duration_since(now)
+                        .as_millis()
+                        .min(i32::MAX as u128) as i32
+                }
+            })
+            .unwrap_or(-1)
+    }
+
+    pub fn dispatch_click(&mut self, id: u32) {
+        self.app.push_event(UiEvent::Click {
+            node_id: NodeId::from_u32(id),
+        });
+    }
+
+    pub fn dispatch_input(&mut self, id: u32, value: String) {
+        self.app.push_event(UiEvent::Change {
+            node_id: NodeId::from_u32(id),
+            value,
+        });
+    }
+
+    pub fn dispatch_submit(&mut self, id: u32, value: String) {
+        self.app.push_event(UiEvent::Submit {
+            node_id: NodeId::from_u32(id),
+            value,
+        });
+    }
+
+    pub fn dispatch_toggle(&mut self, id: u32, checked: bool) {
+        self.app.push_event(UiEvent::Toggle {
+            node_id: NodeId::from_u32(id),
+            checked,
+        });
+    }
+
+    pub fn set_viewport(&mut self, width: u16, height: u16) {
+        self.app.set_viewport_size(width, height);
+        self.app
+            .renderer()
+            .set_viewport_size(width as f32, height as f32);
+    }
+}
+
+pub fn run_file(file: &Path, _args: &[String]) -> Result<()> {
+    let source = std::fs::read_to_string(file)?;
+    let mut runtime = MacosRuntime::new(HostCallbacks::default())?;
+    runtime.load_lua(&source)?;
+
+    runtime.tick()?;
+    println!("macOS runtime mounted. AppKit host bridge scaffold ready.");
+
+    Ok(())
+}
+
+pub fn build_host() -> Result<PathBuf> {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = crate_dir
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("failed to resolve workspace root"))?;
+    let host_path = workspace_root.join("target/debug/rover-macos-host");
+    let script = crate_dir.join("swift/build.sh");
+
+    let status = Command::new(&script)
+        .arg(&host_path)
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to run {}: {}", script.display(), e))?;
+
+    if !status.success() {
+        return Err(anyhow::anyhow!(
+            "failed to build macOS host with status {}",
+            status
+        ));
+    }
+
+    Ok(host_path)
+}
+
+pub fn launch_file(file: &Path, _args: &[String]) -> Result<()> {
+    let host = build_host()?;
+    let status = Command::new(&host)
+        .arg(file)
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to launch {}: {}", host.display(), e))?;
+
+    if !status.success() {
+        return Err(anyhow::anyhow!("macOS host exited with status {}", status));
+    }
+
+    Ok(())
+}

--- a/rover-macos/swift/README.md
+++ b/rover-macos/swift/README.md
@@ -1,0 +1,11 @@
+# rover-macos AppKit Host
+
+Thin native host for `rover-macos`.
+
+Direction:
+- AppKit owns `NSView` objects.
+- Rust owns Rover UI runtime, dirty-node updates, and px layout.
+- Bridge is C/Objective-C style callbacks, no JSON.
+- One native view per Rover `NodeId`.
+
+The Rust ABI is in `rover-macos/src/abi_export.rs`.

--- a/rover-macos/swift/RoverMacosHost.swift
+++ b/rover-macos/swift/RoverMacosHost.swift
@@ -49,8 +49,15 @@ func rover_macos_dispatch_submit(_ runtime: RoverRuntime?, _ id: UInt32, _ value
 @_silgen_name("rover_macos_dispatch_toggle")
 func rover_macos_dispatch_toggle(_ runtime: RoverRuntime?, _ id: UInt32, _ checked: Bool) -> Int32
 
+@_silgen_name("rover_macos_set_viewport")
+func rover_macos_set_viewport(_ runtime: RoverRuntime?, _ width: UInt16, _ height: UInt16) -> Int32
+
 @_silgen_name("rover_macos_last_error")
 func rover_macos_last_error(_ runtime: RoverRuntime?) -> UnsafePointer<CChar>?
+
+final class RoverContainerView: NSView {
+    override var isFlipped: Bool { true }
+}
 
 final class RoverButton: NSButton {
     var nodeID: UInt32 = 0
@@ -117,6 +124,14 @@ final class RoverMacosHost: NSObject, NSApplicationDelegate, NSTextFieldDelegate
         NSApp.terminate(nil)
     }
 
+    func windowDidResize(_ notification: Notification) {
+        guard let content = window?.contentView else { return }
+        let width = UInt16(max(1, min(content.bounds.width, CGFloat(UInt16.max))))
+        let height = UInt16(max(1, min(content.bounds.height, CGFloat(UInt16.max))))
+        _ = rover_macos_set_viewport(runtime, width, height)
+        tick()
+    }
+
     func createView(nodeID: UInt32, kind: Int32) -> RoverNativeView? {
         let view: NSView
         switch kind {
@@ -127,11 +142,12 @@ final class RoverMacosHost: NSObject, NSApplicationDelegate, NSTextFieldDelegate
                 backing: .buffered,
                 defer: false
             )
+            window.contentView = RoverContainerView(frame: NSRect(x: 0, y: 0, width: 900, height: 640))
             window.delegate = self
             window.center()
             window.makeKeyAndOrderFront(nil)
             self.window = window
-            view = window.contentView ?? NSView()
+            view = window.contentView ?? RoverContainerView()
         case 4:
             let text = NSTextField(labelWithString: "")
             text.lineBreakMode = .byWordWrapping
@@ -157,7 +173,7 @@ final class RoverMacosHost: NSObject, NSApplicationDelegate, NSTextFieldDelegate
             scroll.hasHorizontalScroller = false
             view = scroll
         default:
-            view = NSView()
+            view = RoverContainerView()
         }
         views[nodeID] = view
         return Unmanaged.passUnretained(view).toOpaque()

--- a/rover-macos/swift/RoverMacosHost.swift
+++ b/rover-macos/swift/RoverMacosHost.swift
@@ -80,6 +80,7 @@ final class RoverMacosHost: NSObject, NSApplicationDelegate, NSTextFieldDelegate
     private var views: [UInt32: NSView] = [:]
     private var runtime: RoverRuntime?
     private var timer: Timer?
+    private var applyingWindowFrame = false
 
     func start(sourcePath: String) {
         runtime = rover_macos_init_with_callbacks(
@@ -128,6 +129,7 @@ final class RoverMacosHost: NSObject, NSApplicationDelegate, NSTextFieldDelegate
     }
 
     func windowDidResize(_ notification: Notification) {
+        if applyingWindowFrame { return }
         guard let content = window?.contentView else { return }
         let width = UInt16(max(1, min(content.bounds.width, CGFloat(UInt16.max))))
         let height = UInt16(max(1, min(content.bounds.height, CGFloat(UInt16.max))))
@@ -264,7 +266,9 @@ final class RoverMacosHost: NSObject, NSApplicationDelegate, NSTextFieldDelegate
         guard let titlePtr else { return }
         let title = String(data: Data(bytes: titlePtr, count: len), encoding: .utf8) ?? "Rover"
         window?.title = title
+        applyingWindowFrame = true
         window?.setContentSize(NSSize(width: CGFloat(width), height: CGFloat(height)))
+        applyingWindowFrame = false
     }
 
     func removeView(view: RoverNativeView?) {

--- a/rover-macos/swift/RoverMacosHost.swift
+++ b/rover-macos/swift/RoverMacosHost.swift
@@ -1,0 +1,293 @@
+import AppKit
+import Foundation
+
+typealias RoverRuntime = UnsafeMutableRawPointer
+typealias RoverNativeView = UnsafeMutableRawPointer
+
+typealias RoverCreateViewFn = @convention(c) (UInt32, Int32) -> RoverNativeView?
+typealias RoverAppendChildFn = @convention(c) (RoverNativeView?, RoverNativeView?) -> Void
+typealias RoverRemoveViewFn = @convention(c) (RoverNativeView?) -> Void
+typealias RoverSetFrameFn = @convention(c) (RoverNativeView?, Float, Float, Float, Float) -> Void
+typealias RoverSetTextFn = @convention(c) (RoverNativeView?, UnsafePointer<CChar>?, Int) -> Void
+typealias RoverSetBoolFn = @convention(c) (RoverNativeView?, Bool) -> Void
+typealias RoverSetWindowFn = @convention(c) (RoverNativeView?, UnsafePointer<CChar>?, Int, Float, Float) -> Void
+typealias RoverStopAppFn = @convention(c) () -> Void
+
+@_silgen_name("rover_macos_init_with_callbacks")
+func rover_macos_init_with_callbacks(
+    _ createView: RoverCreateViewFn?,
+    _ appendChild: RoverAppendChildFn?,
+    _ removeView: RoverRemoveViewFn?,
+    _ setFrame: RoverSetFrameFn?,
+    _ setText: RoverSetTextFn?,
+    _ setBool: RoverSetBoolFn?,
+    _ setWindow: RoverSetWindowFn?,
+    _ stopApp: RoverStopAppFn?
+) -> RoverRuntime?
+
+@_silgen_name("rover_macos_free")
+func rover_macos_free(_ runtime: RoverRuntime?)
+
+@_silgen_name("rover_macos_load_lua")
+func rover_macos_load_lua(_ runtime: RoverRuntime?, _ source: UnsafePointer<CChar>?) -> Int32
+
+@_silgen_name("rover_macos_tick")
+func rover_macos_tick(_ runtime: RoverRuntime?) -> Int32
+
+@_silgen_name("rover_macos_next_wake_ms")
+func rover_macos_next_wake_ms(_ runtime: RoverRuntime?) -> Int32
+
+@_silgen_name("rover_macos_dispatch_click")
+func rover_macos_dispatch_click(_ runtime: RoverRuntime?, _ id: UInt32) -> Int32
+
+@_silgen_name("rover_macos_dispatch_input")
+func rover_macos_dispatch_input(_ runtime: RoverRuntime?, _ id: UInt32, _ value: UnsafePointer<CChar>?) -> Int32
+
+@_silgen_name("rover_macos_dispatch_submit")
+func rover_macos_dispatch_submit(_ runtime: RoverRuntime?, _ id: UInt32, _ value: UnsafePointer<CChar>?) -> Int32
+
+@_silgen_name("rover_macos_dispatch_toggle")
+func rover_macos_dispatch_toggle(_ runtime: RoverRuntime?, _ id: UInt32, _ checked: Bool) -> Int32
+
+@_silgen_name("rover_macos_last_error")
+func rover_macos_last_error(_ runtime: RoverRuntime?) -> UnsafePointer<CChar>?
+
+final class RoverButton: NSButton {
+    var nodeID: UInt32 = 0
+}
+
+final class RoverTextField: NSTextField {
+    var nodeID: UInt32 = 0
+}
+
+final class RoverCheckbox: NSButton {
+    var nodeID: UInt32 = 0
+}
+
+final class RoverMacosHost: NSObject, NSApplicationDelegate, NSTextFieldDelegate, NSWindowDelegate {
+    static let shared = RoverMacosHost()
+
+    private var window: NSWindow?
+    private var views: [UInt32: NSView] = [:]
+    private var runtime: RoverRuntime?
+    private var timer: Timer?
+
+    func start(sourcePath: String) {
+        runtime = rover_macos_init_with_callbacks(
+            roverCreateView,
+            roverAppendChild,
+            roverRemoveView,
+            roverSetFrame,
+            roverSetText,
+            roverSetBool,
+            roverSetWindow,
+            roverStopApp
+        )
+        guard let runtime else {
+            fatalError("failed to initialize rover macOS runtime")
+        }
+
+        let source: String
+        do {
+            source = try String(contentsOfFile: sourcePath, encoding: .utf8)
+        } catch {
+            fatalError("failed to read Lua file: \(error)")
+        }
+
+        let code = source.withCString { rover_macos_load_lua(runtime, $0) }
+        if code != 0 {
+            fatalError(lastError())
+        }
+
+        tick()
+        scheduleTimer()
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        timer?.invalidate()
+        rover_macos_free(runtime)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        NSApp.terminate(nil)
+    }
+
+    func createView(nodeID: UInt32, kind: Int32) -> RoverNativeView? {
+        let view: NSView
+        switch kind {
+        case 0:
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 900, height: 640),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                backing: .buffered,
+                defer: false
+            )
+            window.delegate = self
+            window.center()
+            window.makeKeyAndOrderFront(nil)
+            self.window = window
+            view = window.contentView ?? NSView()
+        case 4:
+            let text = NSTextField(labelWithString: "")
+            text.lineBreakMode = .byWordWrapping
+            view = text
+        case 5:
+            let button = RoverButton(title: "", target: self, action: #selector(buttonClicked(_:)))
+            button.nodeID = nodeID
+            view = button
+        case 6:
+            let input = RoverTextField(string: "")
+            input.nodeID = nodeID
+            input.delegate = self
+            input.target = self
+            input.action = #selector(inputSubmitted(_:))
+            view = input
+        case 7:
+            let checkbox = RoverCheckbox(checkboxWithTitle: "", target: self, action: #selector(checkboxToggled(_:)))
+            checkbox.nodeID = nodeID
+            view = checkbox
+        case 9:
+            let scroll = NSScrollView()
+            scroll.hasVerticalScroller = true
+            scroll.hasHorizontalScroller = false
+            view = scroll
+        default:
+            view = NSView()
+        }
+        views[nodeID] = view
+        return Unmanaged.passUnretained(view).toOpaque()
+    }
+
+    func appendChild(parent: RoverNativeView?, child: RoverNativeView?) {
+        guard let parent, let child else { return }
+        let parentView = Unmanaged<NSView>.fromOpaque(parent).takeUnretainedValue()
+        let childView = Unmanaged<NSView>.fromOpaque(child).takeUnretainedValue()
+
+        if let scroll = parentView as? NSScrollView {
+            scroll.documentView = childView
+        } else if childView.superview !== parentView {
+            parentView.addSubview(childView)
+        }
+    }
+
+    func setFrame(view: RoverNativeView?, x: Float, y: Float, width: Float, height: Float) {
+        guard let view else { return }
+        let nsView = Unmanaged<NSView>.fromOpaque(view).takeUnretainedValue()
+        nsView.frame = NSRect(x: CGFloat(x), y: CGFloat(y), width: CGFloat(width), height: CGFloat(height))
+    }
+
+    func setText(view: RoverNativeView?, ptr: UnsafePointer<CChar>?, len: Int) {
+        guard let view, let ptr else { return }
+        let data = Data(bytes: ptr, count: len)
+        let value = String(data: data, encoding: .utf8) ?? ""
+        let nsView = Unmanaged<NSView>.fromOpaque(view).takeUnretainedValue()
+
+        if let text = nsView as? NSTextField {
+            text.stringValue = value
+        } else if let button = nsView as? NSButton {
+            button.title = value
+        }
+    }
+
+    func setBool(view: RoverNativeView?, value: Bool) {
+        guard let view else { return }
+        let nsView = Unmanaged<NSView>.fromOpaque(view).takeUnretainedValue()
+        if let button = nsView as? NSButton {
+            button.state = value ? .on : .off
+        }
+    }
+
+    func setWindow(view: RoverNativeView?, titlePtr: UnsafePointer<CChar>?, len: Int, width: Float, height: Float) {
+        guard let titlePtr else { return }
+        let title = String(data: Data(bytes: titlePtr, count: len), encoding: .utf8) ?? "Rover"
+        window?.title = title
+        window?.setContentSize(NSSize(width: CGFloat(width), height: CGFloat(height)))
+    }
+
+    func removeView(view: RoverNativeView?) {
+        guard let view else { return }
+        let nsView = Unmanaged<NSView>.fromOpaque(view).takeUnretainedValue()
+        nsView.removeFromSuperview()
+    }
+
+    @objc private func buttonClicked(_ sender: RoverButton) {
+        _ = rover_macos_dispatch_click(runtime, sender.nodeID)
+        tick()
+    }
+
+    @objc private func checkboxToggled(_ sender: RoverCheckbox) {
+        _ = rover_macos_dispatch_toggle(runtime, sender.nodeID, sender.state == .on)
+        tick()
+    }
+
+    @objc private func inputSubmitted(_ sender: RoverTextField) {
+        sender.stringValue.withCString { value in
+            _ = rover_macos_dispatch_submit(runtime, sender.nodeID, value)
+        }
+        tick()
+    }
+
+    func controlTextDidChange(_ notification: Notification) {
+        guard let input = notification.object as? RoverTextField else { return }
+        input.stringValue.withCString { value in
+            _ = rover_macos_dispatch_input(runtime, input.nodeID, value)
+        }
+        tick()
+    }
+
+    private func scheduleTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    private func tick() {
+        let code = rover_macos_tick(runtime)
+        if code != 0 {
+            fatalError(lastError())
+        }
+    }
+
+    private func lastError() -> String {
+        guard let ptr = rover_macos_last_error(runtime) else { return "unknown rover macOS error" }
+        return String(cString: ptr)
+    }
+}
+
+func roverCreateView(nodeID: UInt32, kind: Int32) -> RoverNativeView? {
+    RoverMacosHost.shared.createView(nodeID: nodeID, kind: kind)
+}
+
+func roverAppendChild(parent: RoverNativeView?, child: RoverNativeView?) {
+    RoverMacosHost.shared.appendChild(parent: parent, child: child)
+}
+
+func roverRemoveView(view: RoverNativeView?) {
+    RoverMacosHost.shared.removeView(view: view)
+}
+
+func roverSetFrame(view: RoverNativeView?, x: Float, y: Float, width: Float, height: Float) {
+    RoverMacosHost.shared.setFrame(view: view, x: x, y: y, width: width, height: height)
+}
+
+func roverSetText(view: RoverNativeView?, ptr: UnsafePointer<CChar>?, len: Int) {
+    RoverMacosHost.shared.setText(view: view, ptr: ptr, len: len)
+}
+
+func roverSetBool(view: RoverNativeView?, value: Bool) {
+    RoverMacosHost.shared.setBool(view: view, value: value)
+}
+
+func roverSetWindow(view: RoverNativeView?, title: UnsafePointer<CChar>?, len: Int, width: Float, height: Float) {
+    RoverMacosHost.shared.setWindow(view: view, titlePtr: title, len: len, width: width, height: height)
+}
+
+func roverStopApp() {
+    NSApp.terminate(nil)
+}

--- a/rover-macos/swift/RoverMacosHost.swift
+++ b/rover-macos/swift/RoverMacosHost.swift
@@ -10,6 +10,7 @@ typealias RoverRemoveViewFn = @convention(c) (RoverNativeView?) -> Void
 typealias RoverSetFrameFn = @convention(c) (RoverNativeView?, Float, Float, Float, Float) -> Void
 typealias RoverSetTextFn = @convention(c) (RoverNativeView?, UnsafePointer<CChar>?, Int) -> Void
 typealias RoverSetBoolFn = @convention(c) (RoverNativeView?, Bool) -> Void
+typealias RoverSetStyleFn = @convention(c) (RoverNativeView?, UnsafePointer<CChar>?, Int, UnsafePointer<CChar>?, Int, Float, UnsafePointer<CChar>?, Int) -> Void
 typealias RoverSetWindowFn = @convention(c) (RoverNativeView?, UnsafePointer<CChar>?, Int, Float, Float) -> Void
 typealias RoverStopAppFn = @convention(c) () -> Void
 
@@ -21,6 +22,7 @@ func rover_macos_init_with_callbacks(
     _ setFrame: RoverSetFrameFn?,
     _ setText: RoverSetTextFn?,
     _ setBool: RoverSetBoolFn?,
+    _ setStyle: RoverSetStyleFn?,
     _ setWindow: RoverSetWindowFn?,
     _ stopApp: RoverStopAppFn?
 ) -> RoverRuntime?
@@ -87,6 +89,7 @@ final class RoverMacosHost: NSObject, NSApplicationDelegate, NSTextFieldDelegate
             roverSetFrame,
             roverSetText,
             roverSetBool,
+            roverSetStyle,
             roverSetWindow,
             roverStopApp
         )
@@ -218,6 +221,45 @@ final class RoverMacosHost: NSObject, NSApplicationDelegate, NSTextFieldDelegate
         }
     }
 
+    func setStyle(view: RoverNativeView?, bgPtr: UnsafePointer<CChar>?, bgLen: Int, borderPtr: UnsafePointer<CChar>?, borderLen: Int, borderWidth: Float, textPtr: UnsafePointer<CChar>?, textLen: Int) {
+        guard let view else { return }
+        let nsView = Unmanaged<NSView>.fromOpaque(view).takeUnretainedValue()
+
+        if let bg = color(ptr: bgPtr, len: bgLen) {
+            nsView.wantsLayer = true
+            nsView.layer?.backgroundColor = bg.cgColor
+        }
+        if let border = color(ptr: borderPtr, len: borderLen) {
+            nsView.wantsLayer = true
+            nsView.layer?.borderColor = border.cgColor
+        }
+        if borderWidth > 0 {
+            nsView.wantsLayer = true
+            nsView.layer?.borderWidth = CGFloat(borderWidth)
+        }
+        if let text = color(ptr: textPtr, len: textLen) {
+            if let field = nsView as? NSTextField {
+                field.textColor = text
+            } else if let button = nsView as? NSButton {
+                button.contentTintColor = text
+            }
+        }
+    }
+
+    private func color(ptr: UnsafePointer<CChar>?, len: Int) -> NSColor? {
+        guard let ptr, len > 0 else { return nil }
+        let raw = String(data: Data(bytes: ptr, count: len), encoding: .utf8) ?? ""
+        guard raw.hasPrefix("#") else { return nil }
+        let hex = String(raw.dropFirst())
+        guard hex.count == 6, let value = Int(hex, radix: 16) else { return nil }
+        return NSColor(
+            red: CGFloat((value >> 16) & 0xff) / 255.0,
+            green: CGFloat((value >> 8) & 0xff) / 255.0,
+            blue: CGFloat(value & 0xff) / 255.0,
+            alpha: 1.0
+        )
+    }
+
     func setWindow(view: RoverNativeView?, titlePtr: UnsafePointer<CChar>?, len: Int, width: Float, height: Float) {
         guard let titlePtr else { return }
         let title = String(data: Data(bytes: titlePtr, count: len), encoding: .utf8) ?? "Rover"
@@ -298,6 +340,10 @@ func roverSetText(view: RoverNativeView?, ptr: UnsafePointer<CChar>?, len: Int) 
 
 func roverSetBool(view: RoverNativeView?, value: Bool) {
     RoverMacosHost.shared.setBool(view: view, value: value)
+}
+
+func roverSetStyle(view: RoverNativeView?, bgPtr: UnsafePointer<CChar>?, bgLen: Int, borderPtr: UnsafePointer<CChar>?, borderLen: Int, borderWidth: Float, textPtr: UnsafePointer<CChar>?, textLen: Int) {
+    RoverMacosHost.shared.setStyle(view: view, bgPtr: bgPtr, bgLen: bgLen, borderPtr: borderPtr, borderLen: borderLen, borderWidth: borderWidth, textPtr: textPtr, textLen: textLen)
 }
 
 func roverSetWindow(view: RoverNativeView?, title: UnsafePointer<CChar>?, len: Int, width: Float, height: Float) {

--- a/rover-macos/swift/build.sh
+++ b/rover-macos/swift/build.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT="${1:-$ROOT/target/debug/rover-macos-host}"
+
+cargo build -p rover-macos
+
+swiftc \
+  "$ROOT/rover-macos/swift/RoverMacosHost.swift" \
+  "$ROOT/rover-macos/swift/main.swift" \
+  -framework AppKit \
+  -L "$ROOT/target/debug" \
+  -lrover_macos \
+  -Xlinker -rpath \
+  -Xlinker "$ROOT/target/debug" \
+  -Xlinker -rpath \
+  -Xlinker @executable_path \
+  -o "$OUT"
+
+echo "$OUT"

--- a/rover-macos/swift/main.swift
+++ b/rover-macos/swift/main.swift
@@ -1,0 +1,17 @@
+import AppKit
+
+let app = NSApplication.shared
+let host = RoverMacosHost.shared
+app.delegate = host
+
+let sourcePath: String
+if CommandLine.arguments.count >= 2 {
+    sourcePath = CommandLine.arguments[1]
+} else if let bundled = Bundle.main.path(forResource: "bundle", ofType: "lua") {
+    sourcePath = bundled
+} else {
+    fatalError("usage: rover-macos-host <app.lua>")
+}
+
+host.start(sourcePath: sourcePath)
+app.run()

--- a/rover-parser/src/specs/data.rs
+++ b/rover-parser/src/specs/data.rs
@@ -282,6 +282,7 @@ pub(super) fn build_specs() -> Vec<ApiSpec> {
                 api_member!("ws_client" => "rover_ws_client_constructor", "Create a WebSocket client.", method),
                 api_member!("ui" => "any", "UI namespace.", field),
                 api_member!("tui" => "any", "Terminal UI namespace.", field),
+                api_member!("macos" => "any", "macOS native UI namespace.", field),
                 api_member!("signal" => "rover_signal_constructor", "Create a reactive signal.", method),
                 api_member!("derive" => "rover_derive", "Create a derived reactive value.", method)
             ]

--- a/rover-tui/src/layout.rs
+++ b/rover-tui/src/layout.rs
@@ -122,8 +122,8 @@ pub fn compute_layout(
 
         UiNode::Column { children }
         | UiNode::View { children }
-        | UiNode::MacosWindow { children, .. }
-        | UiNode::MacosScrollView { children } => {
+        | UiNode::ScrollView { children }
+        | UiNode::MacosWindow { children, .. } => {
             let children = flatten_list_nodes(registry, children);
             let mut total_height: u16 = 0;
             let mut max_width: u16 = 0;
@@ -805,8 +805,8 @@ fn child_nodes(registry: &UiRegistry, node_id: NodeId) -> Vec<NodeId> {
         | UiNode::View { children }
         | UiNode::Stack { children }
         | UiNode::List { children, .. }
-        | UiNode::MacosWindow { children, .. }
-        | UiNode::MacosScrollView { children } => children.clone(),
+        | UiNode::ScrollView { children }
+        | UiNode::MacosWindow { children, .. } => children.clone(),
         UiNode::ScrollBox {
             child: Some(child),
             stick_bottom: _,
@@ -918,13 +918,13 @@ pub fn node_content(node: &UiNode) -> Option<String> {
         | UiNode::Row { .. }
         | UiNode::View { .. }
         | UiNode::ScrollBox { .. }
+        | UiNode::ScrollView { .. }
         | UiNode::Stack { .. }
         | UiNode::FullScreen { .. }
         | UiNode::Conditional { .. }
         | UiNode::KeyArea { .. }
         | UiNode::List { .. }
         | UiNode::MacosWindow { .. }
-        | UiNode::MacosScrollView { .. }
         | UiNode::Image { .. } => None,
     }
 }

--- a/rover-tui/src/layout.rs
+++ b/rover-tui/src/layout.rs
@@ -120,7 +120,10 @@ pub fn compute_layout(
             (width, height)
         }
 
-        UiNode::Column { children } | UiNode::View { children } => {
+        UiNode::Column { children }
+        | UiNode::View { children }
+        | UiNode::MacosWindow { children, .. }
+        | UiNode::MacosScrollView { children } => {
             let children = flatten_list_nodes(registry, children);
             let mut total_height: u16 = 0;
             let mut max_width: u16 = 0;
@@ -801,7 +804,9 @@ fn child_nodes(registry: &UiRegistry, node_id: NodeId) -> Vec<NodeId> {
         | UiNode::Row { children }
         | UiNode::View { children }
         | UiNode::Stack { children }
-        | UiNode::List { children, .. } => children.clone(),
+        | UiNode::List { children, .. }
+        | UiNode::MacosWindow { children, .. }
+        | UiNode::MacosScrollView { children } => children.clone(),
         UiNode::ScrollBox {
             child: Some(child),
             stick_bottom: _,
@@ -918,6 +923,8 @@ pub fn node_content(node: &UiNode) -> Option<String> {
         | UiNode::Conditional { .. }
         | UiNode::KeyArea { .. }
         | UiNode::List { .. }
+        | UiNode::MacosWindow { .. }
+        | UiNode::MacosScrollView { .. }
         | UiNode::Image { .. } => None,
     }
 }

--- a/rover-tui/src/renderer.rs
+++ b/rover-tui/src/renderer.rs
@@ -450,8 +450,8 @@ impl TuiRenderer {
             | UiNode::View { children }
             | UiNode::Stack { children }
             | UiNode::List { children, .. }
-            | UiNode::MacosWindow { children, .. }
-            | UiNode::MacosScrollView { children } => flatten_list_nodes(registry, children),
+            | UiNode::ScrollView { children }
+            | UiNode::MacosWindow { children, .. } => flatten_list_nodes(registry, children),
             UiNode::ScrollBox { child, .. } => child.iter().copied().collect(),
             UiNode::Conditional { child, .. } => {
                 let raw: Vec<NodeId> = child.iter().copied().collect();

--- a/rover-tui/src/renderer.rs
+++ b/rover-tui/src/renderer.rs
@@ -449,7 +449,9 @@ impl TuiRenderer {
             | UiNode::Row { children }
             | UiNode::View { children }
             | UiNode::Stack { children }
-            | UiNode::List { children, .. } => flatten_list_nodes(registry, children),
+            | UiNode::List { children, .. }
+            | UiNode::MacosWindow { children, .. }
+            | UiNode::MacosScrollView { children } => flatten_list_nodes(registry, children),
             UiNode::ScrollBox { child, .. } => child.iter().copied().collect(),
             UiNode::Conditional { child, .. } => {
                 let raw: Vec<NodeId> = child.iter().copied().collect();

--- a/rover-tui/src/runner.rs
+++ b/rover-tui/src/runner.rs
@@ -318,7 +318,9 @@ fn collect_focusable_nodes(registry: &UiRegistry, node_id: NodeId, out: &mut Vec
         | UiNode::Row { children }
         | UiNode::View { children }
         | UiNode::Stack { children }
-        | UiNode::List { children, .. } => {
+        | UiNode::List { children, .. }
+        | UiNode::MacosWindow { children, .. }
+        | UiNode::MacosScrollView { children } => {
             let children = children.clone();
             for child_id in children {
                 collect_focusable_nodes(registry, child_id, out);

--- a/rover-tui/src/runner.rs
+++ b/rover-tui/src/runner.rs
@@ -319,8 +319,8 @@ fn collect_focusable_nodes(registry: &UiRegistry, node_id: NodeId, out: &mut Vec
         | UiNode::View { children }
         | UiNode::Stack { children }
         | UiNode::List { children, .. }
-        | UiNode::MacosWindow { children, .. }
-        | UiNode::MacosScrollView { children } => {
+        | UiNode::ScrollView { children }
+        | UiNode::MacosWindow { children, .. } => {
             let children = children.clone();
             for child_id in children {
                 collect_focusable_nodes(registry, child_id, out);

--- a/rover-ui/src/app.rs
+++ b/rover-ui/src/app.rs
@@ -191,12 +191,19 @@ impl<R: Renderer> App<R> {
             let Ok(pending) = self.scheduler.borrow_mut().take_pending(id) else {
                 continue;
             };
-            match run_coroutine_with_delay(&self.lua, &self.runtime, &pending.thread, LuaValue::Nil)? {
+            match run_coroutine_with_delay(
+                &self.lua,
+                &self.runtime,
+                &pending.thread,
+                LuaValue::Nil,
+            )? {
                 CoroutineResult::Completed => {}
                 CoroutineResult::YieldedDelay { delay_ms } => {
-                    self.scheduler
-                        .borrow_mut()
-                        .schedule_delay_with_id(id, pending.thread, delay_ms);
+                    self.scheduler.borrow_mut().schedule_delay_with_id(
+                        id,
+                        pending.thread,
+                        delay_ms,
+                    );
                 }
                 CoroutineResult::YieldedOther => {}
             }

--- a/rover-ui/src/lua/macos/module.lua
+++ b/rover-ui/src/lua/macos/module.lua
@@ -9,7 +9,7 @@ end
 
 function M.scroll_view(props)
   props = props or {}
-  return ui.__macos_scroll_view(props)
+  return ui.scroll_view(props)
 end
 
 return M

--- a/rover-ui/src/lua/macos/module.lua
+++ b/rover-ui/src/lua/macos/module.lua
@@ -1,0 +1,15 @@
+local ui = rover.ui
+
+local M = {}
+
+function M.window(props)
+  props = props or {}
+  return ui.__macos_window(props)
+end
+
+function M.scroll_view(props)
+  props = props or {}
+  return ui.__macos_scroll_view(props)
+end
+
+return M

--- a/rover-ui/src/lua/mod.rs
+++ b/rover-ui/src/lua/mod.rs
@@ -11,7 +11,7 @@ use crate::platform::{UiCapability, ViewportSignals};
 use crate::{signal::SignalValue, ui::ui::LuaUi};
 use derived::LuaDerived;
 use mlua::{Function, Lua, Result, Table, UserData, Value};
-use rover_types::{AuthReason, DeniedError};
+use rover_types::DeniedError;
 use signal::LuaSignal;
 
 /// Marker for delayed coroutine execution
@@ -177,7 +177,13 @@ pub fn register_ui_module(lua: &Lua, rover_table: &Table) -> Result<()> {
         rover_table.set("tui", tui_module)?;
     }
 
+    if crate::lua::helpers::has_capability(lua, UiCapability::MacosNamespace)? {
+        let macos_module = create_macos_module(lua)?;
+        rover_table.set("macos", macos_module)?;
+    }
+
     register_tui_preload_module(lua)?;
+    register_macos_preload_module(lua)?;
 
     Ok(())
 }
@@ -193,7 +199,10 @@ fn register_tui_preload_module(lua: &Lua) -> Result<()> {
                 let err =
                     DeniedError::capability(UiCapability::TuiNamespace.as_str(), target.as_str());
                 err.emit();
-                return Err(mlua::Error::RuntimeError(err.user_message()));
+                return Err(mlua::Error::RuntimeError(format!(
+                    "TUI namespace denied by capability policy: {}",
+                    err.user_message()
+                )));
             }
 
             let rover_table: Table = lua.globals().get("rover")?;
@@ -214,6 +223,44 @@ fn register_tui_preload_module(lua: &Lua) -> Result<()> {
 fn create_tui_module(lua: &Lua) -> Result<Table> {
     lua.load(include_str!("tui/module.lua"))
         .set_name("rover_tui_module.lua")
+        .eval()
+}
+
+fn register_macos_preload_module(lua: &Lua) -> Result<()> {
+    let package: Table = lua.globals().get("package")?;
+    let preload: Table = package.get("preload")?;
+    preload.set(
+        "rover.macos",
+        lua.create_function(|lua, _name: Value| {
+            let target = crate::lua::helpers::get_target(lua)?;
+            if !crate::lua::helpers::has_capability(lua, UiCapability::MacosNamespace)? {
+                let err =
+                    DeniedError::capability(UiCapability::MacosNamespace.as_str(), target.as_str());
+                err.emit();
+                return Err(mlua::Error::RuntimeError(format!(
+                    "macOS namespace denied by capability policy: {}",
+                    err.user_message()
+                )));
+            }
+
+            let rover_table: Table = lua.globals().get("rover")?;
+            match rover_table.get::<Value>("macos")? {
+                Value::Table(module) => Ok(module),
+                _ => {
+                    let module = create_macos_module(lua)?;
+                    rover_table.set("macos", module.clone())?;
+                    Ok(module)
+                }
+            }
+        })?,
+    )?;
+
+    Ok(())
+}
+
+fn create_macos_module(lua: &Lua) -> Result<Table> {
+    lua.load(include_str!("macos/module.lua"))
+        .set_name("rover_macos_module.lua")
         .eval()
 }
 
@@ -271,6 +318,44 @@ mod tests {
 
         assert!(!ok);
         assert!(err.contains("denied by capability policy"));
+    }
+
+    #[test]
+    fn should_deny_macos_namespace_on_web_by_default() {
+        let lua = setup_lua(UiRuntimeConfig::new(UiTarget::Web));
+
+        let (ok, err): (bool, String) = lua
+            .load(
+                r#"
+                local ok, err = pcall(function()
+                    require("rover.macos")
+                end)
+                return ok, tostring(err)
+            "#,
+            )
+            .eval()
+            .unwrap();
+
+        assert!(!ok);
+        assert!(err.contains("macos_namespace"));
+    }
+
+    #[test]
+    fn should_allow_macos_namespace_on_macos_target() {
+        let lua = setup_lua(UiRuntimeConfig::new(UiTarget::Macos));
+
+        let (global_type, required_type): (String, String) = lua
+            .load(
+                r#"
+                local macos = require("rover.macos")
+                return type(rover.macos.window), type(macos.scroll_view)
+            "#,
+            )
+            .eval()
+            .unwrap();
+
+        assert_eq!(global_type, "function");
+        assert_eq!(required_type, "function");
     }
 
     #[test]

--- a/rover-ui/src/platform.rs
+++ b/rover-ui/src/platform.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 pub enum UiTarget {
     Tui,
     Web,
+    Macos,
     Mobile,
     Unknown,
 }
@@ -15,6 +16,7 @@ impl UiTarget {
         match self {
             UiTarget::Tui => "tui",
             UiTarget::Web => "web",
+            UiTarget::Macos => "macos",
             UiTarget::Mobile => "mobile",
             UiTarget::Unknown => "unknown",
         }
@@ -25,18 +27,21 @@ impl UiTarget {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UiCapability {
     TuiNamespace,
+    MacosNamespace,
 }
 
 impl UiCapability {
     pub fn as_str(self) -> &'static str {
         match self {
             UiCapability::TuiNamespace => "tui_namespace",
+            UiCapability::MacosNamespace => "macos_namespace",
         }
     }
 
     fn allowed_by_default(self, target: UiTarget) -> bool {
         match self {
             UiCapability::TuiNamespace => target == UiTarget::Tui,
+            UiCapability::MacosNamespace => target == UiTarget::Macos,
         }
     }
 }

--- a/rover-ui/src/ui/node.rs
+++ b/rover-ui/src/ui/node.rs
@@ -103,6 +103,9 @@ pub enum UiNode {
         child: Option<NodeId>,
         stick_bottom: bool,
     },
+    ScrollView {
+        children: Vec<NodeId>,
+    },
     Stack {
         children: Vec<NodeId>,
     },
@@ -142,9 +145,6 @@ pub enum UiNode {
         title: String,
         width: u16,
         height: u16,
-        children: Vec<NodeId>,
-    },
-    MacosScrollView {
         children: Vec<NodeId>,
     },
 }

--- a/rover-ui/src/ui/node.rs
+++ b/rover-ui/src/ui/node.rs
@@ -138,6 +138,15 @@ pub enum UiNode {
         items_effect: EffectId,
         children: Vec<NodeId>,
     },
+    MacosWindow {
+        title: String,
+        width: u16,
+        height: u16,
+        children: Vec<NodeId>,
+    },
+    MacosScrollView {
+        children: Vec<NodeId>,
+    },
 }
 
 /// Text content can be static or reactive

--- a/rover-ui/src/ui/stub.rs
+++ b/rover-ui/src/ui/stub.rs
@@ -213,6 +213,31 @@ impl StubRenderer {
                     }
                     self.log(&format!("{}}}", indent_str));
                 }
+                UiNode::MacosWindow {
+                    title,
+                    width,
+                    height,
+                    children,
+                } => {
+                    self.log(&format!(
+                        "{}MacosWindow(id={:?}, title=\"{}\", width={}, height={}) {{",
+                        indent_str, node_id, title, width, height
+                    ));
+                    for &child_id in children {
+                        self.print_node(registry, child_id, indent + 1);
+                    }
+                    self.log(&format!("{}}}", indent_str));
+                }
+                UiNode::MacosScrollView { children } => {
+                    self.log(&format!(
+                        "{}MacosScrollView(id={:?}) {{",
+                        indent_str, node_id
+                    ));
+                    for &child_id in children {
+                        self.print_node(registry, child_id, indent + 1);
+                    }
+                    self.log(&format!("{}}}", indent_str));
+                }
             }
         }
     }
@@ -370,6 +395,20 @@ impl Renderer for StubRenderer {
                     }
                     UiNode::List { children, .. } => {
                         self.log(&format!("  Updated List(id={:?}) {{", node_id));
+                        for &child_id in children {
+                            self.print_node(registry, child_id, 3);
+                        }
+                        self.log("  }");
+                    }
+                    UiNode::MacosWindow { children, .. } => {
+                        self.log(&format!("  Updated MacosWindow(id={:?}) {{", node_id));
+                        for &child_id in children {
+                            self.print_node(registry, child_id, 3);
+                        }
+                        self.log("  }");
+                    }
+                    UiNode::MacosScrollView { children } => {
+                        self.log(&format!("  Updated MacosScrollView(id={:?}) {{", node_id));
                         for &child_id in children {
                             self.print_node(registry, child_id, 3);
                         }

--- a/rover-ui/src/ui/stub.rs
+++ b/rover-ui/src/ui/stub.rs
@@ -115,6 +115,13 @@ impl StubRenderer {
                     }
                     self.log(&format!("{}}}", indent_str));
                 }
+                UiNode::ScrollView { children } => {
+                    self.log(&format!("{}ScrollView(id={:?}) {{", indent_str, node_id));
+                    for &child_id in children {
+                        self.print_node(registry, child_id, indent + 1);
+                    }
+                    self.log(&format!("{}}}", indent_str));
+                }
                 UiNode::Stack { children } => {
                     self.log(&format!("{}Stack(id={:?}) {{", indent_str, node_id));
                     for &child_id in children {
@@ -228,16 +235,6 @@ impl StubRenderer {
                     }
                     self.log(&format!("{}}}", indent_str));
                 }
-                UiNode::MacosScrollView { children } => {
-                    self.log(&format!(
-                        "{}MacosScrollView(id={:?}) {{",
-                        indent_str, node_id
-                    ));
-                    for &child_id in children {
-                        self.print_node(registry, child_id, indent + 1);
-                    }
-                    self.log(&format!("{}}}", indent_str));
-                }
             }
         }
     }
@@ -328,6 +325,13 @@ impl Renderer for StubRenderer {
                         }
                         self.log("  }");
                     }
+                    UiNode::ScrollView { children } => {
+                        self.log(&format!("  Updated ScrollView(id={:?}) {{", node_id));
+                        for &child_id in children {
+                            self.print_node(registry, child_id, 3);
+                        }
+                        self.log("  }");
+                    }
                     UiNode::Stack { .. } => {
                         self.log(&format!("  Updated Stack(id={:?})", node_id));
                     }
@@ -402,13 +406,6 @@ impl Renderer for StubRenderer {
                     }
                     UiNode::MacosWindow { children, .. } => {
                         self.log(&format!("  Updated MacosWindow(id={:?}) {{", node_id));
-                        for &child_id in children {
-                            self.print_node(registry, child_id, 3);
-                        }
-                        self.log("  }");
-                    }
-                    UiNode::MacosScrollView { children } => {
-                        self.log(&format!("  Updated MacosScrollView(id={:?}) {{", node_id));
                         for &child_id in children {
                             self.print_node(registry, child_id, 3);
                         }

--- a/rover-ui/src/ui/style.rs
+++ b/rover-ui/src/ui/style.rs
@@ -69,13 +69,13 @@ impl NodeStyle {
         if let Some(v) = to_u16(get_alias(table, &["padding"])?) {
             style.ops.push(StyleOp::Padding(v));
         }
-        if let Some(v) = to_string(get_alias(table, &["backgroundColor", "bg_color"])?) {
+        if let Some(v) = to_string(get_alias(table, &["bg_color"])?) {
             style.ops.push(StyleOp::BgColor(v));
         }
-        if let Some(v) = to_string(get_alias(table, &["borderColor", "border_color"])?) {
+        if let Some(v) = to_string(get_alias(table, &["border_color"])?) {
             style.ops.push(StyleOp::BorderColor(v));
         }
-        if let Some(v) = to_u16(get_alias(table, &["borderWidth", "border_width"])?) {
+        if let Some(v) = to_u16(get_alias(table, &["border_width"])?) {
             style.ops.push(StyleOp::BorderWidth(v));
         }
 
@@ -111,10 +111,7 @@ impl NodeStyle {
 
         style.width = parse_size_opt(get_alias(table, &["width"])?);
         style.height = parse_size_opt(get_alias(table, &["height"])?);
-        style.color = to_string(get_alias(
-            table,
-            &["color", "textColor", "fg_color", "text_color"],
-        )?);
+        style.color = to_string(get_alias(table, &["color", "fg_color", "text_color"])?);
 
         if let Some(pos) = to_string(get_alias(table, &["position"])?) {
             style.position = match pos.as_str() {
@@ -129,10 +126,10 @@ impl NodeStyle {
         style.right = to_i32(get_alias(table, &["right"])?);
         style.bottom = to_i32(get_alias(table, &["bottom"])?);
 
-        style.grow = to_f64(get_alias(table, &["grow", "flexGrow"])?);
+        style.grow = to_f64(get_alias(table, &["grow", "flex_grow"])?);
         style.gap = to_u16(get_alias(table, &["gap"])?);
-        style.justify = to_string(get_alias(table, &["justify", "justifyContent"])?);
-        style.align = to_string(get_alias(table, &["align", "alignItems"])?);
+        style.justify = to_string(get_alias(table, &["justify", "justify_content"])?);
+        style.align = to_string(get_alias(table, &["align", "align_items"])?);
         style.horizontal =
             to_string(get_alias(table, &["horizontal"])?).or_else(|| style.justify.clone());
         style.vertical =

--- a/rover-ui/src/ui/ui.rs
+++ b/rover-ui/src/ui/ui.rs
@@ -331,6 +331,17 @@ impl UserData for LuaUi {
             Ok(LuaNode::new(node_id))
         });
 
+        methods.add_function("scroll_view", |lua, props: Table| {
+            let registry_rc = get_registry_rc(lua)?;
+            let children = extract_children(lua, &props)?;
+
+            let node = UiNode::ScrollView { children };
+            let node_id = registry_rc.borrow_mut().create_node(node);
+            apply_mod_to_node(lua, registry_rc.clone(), &props, node_id)?;
+
+            Ok(LuaNode::new(node_id))
+        });
+
         // Internal TUI-only constructor (exposed via rover.tui.scroll_box)
         methods.add_function("__tui_scroll_box", |lua, props: Table| {
             ensure_tui_target(lua)?;
@@ -469,7 +480,7 @@ impl UserData for LuaUi {
             let registry_rc = get_registry_rc(lua)?;
             let children = extract_children(lua, &props)?;
 
-            let node = UiNode::MacosScrollView { children };
+            let node = UiNode::ScrollView { children };
             let node_id = registry_rc.borrow_mut().create_node(node);
             apply_mod_to_node(lua, registry_rc.clone(), &props, node_id)?;
 
@@ -1087,8 +1098,8 @@ fn list_child_ids(node: &UiNode) -> Vec<super::node::NodeId> {
         | UiNode::View { children }
         | UiNode::Stack { children }
         | UiNode::List { children, .. }
-        | UiNode::MacosWindow { children, .. }
-        | UiNode::MacosScrollView { children } => children.clone(),
+        | UiNode::ScrollView { children }
+        | UiNode::MacosWindow { children, .. } => children.clone(),
         UiNode::Conditional { child, .. }
         | UiNode::KeyArea { child, .. }
         | UiNode::FullScreen { child, .. } => child.iter().copied().collect(),

--- a/rover-ui/src/ui/ui.rs
+++ b/rover-ui/src/ui/ui.rs
@@ -49,6 +49,19 @@ fn ensure_tui_target(lua: &mlua::Lua) -> mlua::Result<()> {
     )))
 }
 
+fn ensure_macos_target(lua: &mlua::Lua) -> mlua::Result<()> {
+    let target = crate::lua::helpers::get_target(lua)?;
+    if crate::lua::helpers::has_capability(lua, crate::platform::UiCapability::MacosNamespace)? {
+        return Ok(());
+    }
+
+    Err(mlua::Error::RuntimeError(format!(
+        "macOS node constructor denied by capability policy (capability={}, target={})",
+        crate::platform::UiCapability::MacosNamespace.as_str(),
+        target.as_str()
+    )))
+}
+
 impl UserData for LuaUi {
     fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
         methods.add_function("text", |lua, props: Table| {
@@ -414,6 +427,51 @@ impl UserData for LuaUi {
             if let Some(effect_id) = on_key {
                 registry_rc.borrow_mut().attach_effect(node_id, effect_id);
             }
+
+            Ok(LuaNode::new(node_id))
+        });
+
+        methods.add_function("__macos_window", |lua, props: Table| {
+            ensure_macos_target(lua)?;
+            let registry_rc = get_registry_rc(lua)?;
+
+            let title = match props.get::<Value>("title")? {
+                Value::String(s) => s.to_str()?.to_string(),
+                Value::Nil => "Rover".to_string(),
+                value => value.to_string()?,
+            };
+            let width = match props.get::<Value>("width")? {
+                Value::Integer(n) => n.clamp(1, u16::MAX as i64) as u16,
+                Value::Number(n) => n.clamp(1.0, u16::MAX as f64) as u16,
+                _ => 900,
+            };
+            let height = match props.get::<Value>("height")? {
+                Value::Integer(n) => n.clamp(1, u16::MAX as i64) as u16,
+                Value::Number(n) => n.clamp(1.0, u16::MAX as f64) as u16,
+                _ => 640,
+            };
+            let children = extract_children(lua, &props)?;
+
+            let node = UiNode::MacosWindow {
+                title,
+                width,
+                height,
+                children,
+            };
+            let node_id = registry_rc.borrow_mut().create_node(node);
+            apply_mod_to_node(lua, registry_rc.clone(), &props, node_id)?;
+
+            Ok(LuaNode::new(node_id))
+        });
+
+        methods.add_function("__macos_scroll_view", |lua, props: Table| {
+            ensure_macos_target(lua)?;
+            let registry_rc = get_registry_rc(lua)?;
+            let children = extract_children(lua, &props)?;
+
+            let node = UiNode::MacosScrollView { children };
+            let node_id = registry_rc.borrow_mut().create_node(node);
+            apply_mod_to_node(lua, registry_rc.clone(), &props, node_id)?;
 
             Ok(LuaNode::new(node_id))
         });
@@ -1028,7 +1086,9 @@ fn list_child_ids(node: &UiNode) -> Vec<super::node::NodeId> {
         | UiNode::Row { children }
         | UiNode::View { children }
         | UiNode::Stack { children }
-        | UiNode::List { children, .. } => children.clone(),
+        | UiNode::List { children, .. }
+        | UiNode::MacosWindow { children, .. }
+        | UiNode::MacosScrollView { children } => children.clone(),
         UiNode::Conditional { child, .. }
         | UiNode::KeyArea { child, .. }
         | UiNode::FullScreen { child, .. } => child.iter().copied().collect(),

--- a/rover-ui/src/ui/ui.rs
+++ b/rover-ui/src/ui/ui.rs
@@ -1486,8 +1486,9 @@ fn resolve_style_value(theme: &Table, key: &Value, value: Value) -> mlua::Result
 
     match key_name.as_str() {
         "padding" | "gap" => Ok(Value::Integer(resolve_theme_space(theme, unwrapped)? as i64)),
-        "backgroundColor" | "bg_color" | "borderColor" | "border_color" | "color" | "textColor"
-        | "fg_color" | "text_color" => resolve_theme_color(theme, unwrapped),
+        "bg_color" | "border_color" | "color" | "fg_color" | "text_color" => {
+            resolve_theme_color(theme, unwrapped)
+        }
         _ => Ok(unwrapped),
     }
 }

--- a/rover-ui/tests/style_mod.rs
+++ b/rover-ui/tests/style_mod.rs
@@ -12,7 +12,7 @@ fn test_style_object_is_supported() {
             r#"
             local ui = rover.ui
             local node = ui.view {
-                style = { backgroundColor = "surface" },
+                style = { bg_color = "surface" },
                 ui.text { "x" }
             }
             rover.render = function() return node end
@@ -38,7 +38,7 @@ fn test_reactive_style_updates_style() {
 
             function rover.render()
                 return ui.view {
-                    style = { backgroundColor = _G.bg },
+                    style = { bg_color = _G.bg },
                     ui.text { "x" },
                 }
             end

--- a/rover-web-wasm/src/lib.rs
+++ b/rover-web-wasm/src/lib.rs
@@ -108,7 +108,10 @@ impl WebRenderer {
                     body
                 )
             }
-            UiNode::View { children } | UiNode::List { children, .. } => {
+            UiNode::View { children }
+            | UiNode::List { children, .. }
+            | UiNode::MacosWindow { children, .. }
+            | UiNode::MacosScrollView { children } => {
                 let body = self.render_children(registry, children);
                 format!("<div{}>{}</div>", style_attr(registry, node_id, &[]), body)
             }

--- a/rover-web-wasm/src/lib.rs
+++ b/rover-web-wasm/src/lib.rs
@@ -110,8 +110,8 @@ impl WebRenderer {
             }
             UiNode::View { children }
             | UiNode::List { children, .. }
-            | UiNode::MacosWindow { children, .. }
-            | UiNode::MacosScrollView { children } => {
+            | UiNode::ScrollView { children }
+            | UiNode::MacosWindow { children, .. } => {
                 let body = self.render_children(registry, children);
                 format!("<div{}>{}</div>", style_attr(registry, node_id, &[]), body)
             }


### PR DESCRIPTION
## Summary
- add native `rover-macos` runtime + Swift AppKit host bridge, wired into `rover run --platform macos`
- sync macOS viewport updates with UI registry dirty-marking and apply parent-relative native frames to fix layout/resize behavior
- update macOS example + docs, including `ROVER_WEB_SKIP_AUTO_BUILD` / `ROVER_WEB_ASSETS_TAR_GZ` dev env vars for faster non-web loops